### PR TITLE
Hydrate previous subagent sessions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-subagent-statusline",
-  "version": "0.4.0",
+  "version": "0.3.0",
   "description": "OpenCode plugin that exposes subagent session statusline state",
   "type": "module",
   "main": "./dist/tui.js",

--- a/src/events.ts
+++ b/src/events.ts
@@ -364,7 +364,7 @@ export function applySubagentEvent(state: StatuslineState, event: unknown): bool
   const type = asString(e.type);
   if (!type) return false;
 
-  if (type === "session.created") {
+  if (type === "session.created" || type === "session.updated") {
     const child = extractCreatedChild(e);
     if (child) {
       const details = extractChildDetails(e);

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -10,13 +10,14 @@ import { appendFileSync, existsSync, mkdirSync, readFileSync, readdirSync } from
 import { writeFile } from "node:fs/promises";
 import os from "node:os";
 import { dirname, join } from "node:path";
-import { For, Show, createMemo, createSignal } from "solid-js";
+import { For, Show, createEffect, createMemo, createSignal } from "solid-js";
 import type { Accessor } from "solid-js";
 import { applySubagentEvent, extractChildDetails } from "./events.js";
 import { byPriority, formatDuration, renderStatusLine } from "./render.js";
 import {
   createEmptyState,
   getCounts,
+  markChildStatus,
   resolveStatePath,
   resolveTextPath,
   saveState,
@@ -659,11 +660,282 @@ function HomeBottomStatus(props: {
   );
 }
 
+async function hydratePreviousSubagents(
+  api: TuiPluginApi,
+  currentSessionID: string,
+  statePath: string,
+  textPath: string,
+  setState: (fn: (prev: StatuslineState) => StatuslineState) => void,
+) : Promise<boolean> {
+  if (!currentSessionID) return false;
+
+  try {
+    const directory = api.state.path.directory;
+    const sessionClient = api.client.session;
+    let topLevelHydrationFailed = false;
+
+    const [childrenResp, messagesResp, statusResp] = await Promise.all([
+      (async () => {
+        const response = await safeReadAsync(() =>
+          sessionClient?.children?.({ sessionID: currentSessionID, directory }) ??
+            Promise.resolve({ data: [] }),
+        );
+        if (!response) topLevelHydrationFailed = true;
+        return response;
+      })(),
+      (async () => {
+        const response = await safeReadAsync(() =>
+          sessionClient?.messages?.({ sessionID: currentSessionID, directory }) ??
+            Promise.resolve({ data: [] }),
+        );
+        if (!response) topLevelHydrationFailed = true;
+        return response;
+      })(),
+      (async () => {
+        const response = await safeReadAsync(() =>
+          sessionClient?.status?.({ directory }) ?? Promise.resolve({ data: {} }),
+        );
+        if (!response) topLevelHydrationFailed = true;
+        return response;
+      })(),
+    ]);
+
+    const children = Array.isArray(childrenResp?.data) ? childrenResp.data : [];
+    const messages = Array.isArray(messagesResp?.data) ? messagesResp.data : [];
+    const allStatuses = asRecord(statusResp?.data) ?? {};
+    let childHydrationFailed = false;
+    const childMessageResults = await Promise.all(
+      children.map(async (child) => {
+        const session = asRecord(child);
+        const childID = typeof session?.id === "string" ? session.id : undefined;
+        if (!childID) {
+          return { childID: undefined, completedAt: undefined, hasError: false };
+        }
+        const childMessagesResp = await safeReadAsync(() =>
+          sessionClient?.messages?.({ sessionID: childID, directory }) ??
+            Promise.resolve({ data: [] }),
+        );
+        if (!childMessagesResp) {
+          childHydrationFailed = true;
+        }
+        const childMessages = Array.isArray(childMessagesResp?.data)
+          ? childMessagesResp.data
+          : [];
+        return { childID, ...summarizeAssistantMessages(childMessages) };
+      }),
+    );
+    const childErrors = new Set(
+      childMessageResults
+        .filter((result) => result.childID && result.hasError)
+        .map((result) => result.childID as string),
+    );
+    const childCompletedAt = new Map(
+      childMessageResults
+        .filter((result) => result.childID && result.completedAt)
+        .map((result) => [result.childID as string, result.completedAt as string]),
+    );
+
+    setState((current) => {
+      const next = cloneState(current);
+      let changed = false;
+
+      for (const rawSession of children) {
+        const session = asRecord(rawSession);
+        if (!session || typeof session.id !== "string") continue;
+        const fakeEvent = {
+          type: "session.created",
+          properties: {
+            sessionID: session.id,
+            info: session,
+          },
+        };
+        if (applySubagentEvent(next, fakeEvent)) changed = true;
+
+        const status = asRecord(allStatuses[session.id]);
+        const isBusy = status?.type === "busy";
+        const endedAt = childCompletedAt.get(session.id) ?? sessionTimestamp(session, "updated");
+        if (!isBusy && endedAt) {
+          const childStatus = childErrors.has(session.id) ? "error" : "done";
+          if (markChildStatus(next, session.id, childStatus, endedAt)) changed = true;
+        }
+      }
+
+      for (const rawMessage of messages) {
+        const message = asRecord(rawMessage);
+        const info = asRecord(message?.info);
+        const parts = Array.isArray(message?.parts) ? message.parts : [];
+        const parentMessageID = messageIDOf(message);
+        const isAssistant = info?.role === "assistant";
+        const time = asRecord(info?.time);
+        const eventInfo = time ? { time } : undefined;
+        const completedAt = timestampFromUnknown(time?.completed);
+        const isCompleted = typeof completedAt === "string";
+        const hasError = !!info?.error;
+
+        for (const rawPart of parts) {
+          const part = asRecord(rawPart);
+          if (!part) continue;
+          const partWithMessageID =
+            typeof part.messageID === "string" && part.messageID.length > 0
+              ? part
+              : parentMessageID
+                ? { ...part, messageID: parentMessageID }
+                : part;
+          if (
+            part.type === "subtask" ||
+            (part.type === "tool" && (part.tool === "delegate" || part.tool === "task"))
+          ) {
+            const fakeEvent = {
+              type: "message.part.updated",
+              properties: {
+                sessionID: currentSessionID,
+                info: eventInfo,
+                part: partWithMessageID,
+              },
+            };
+            if (applySubagentEvent(next, fakeEvent)) changed = true;
+
+            if (part.type === "subtask" && isAssistant && isCompleted) {
+              const childID = `subtask:${part.id}`;
+              const status = hasError ? "error" : "done";
+              if (markChildStatus(next, childID, status, completedAt)) changed = true;
+            }
+          }
+        }
+      }
+
+      if (!changed) return current;
+      persistStateSnapshot(statePath, textPath, next);
+      return next;
+    });
+    if (topLevelHydrationFailed || childHydrationFailed) return false;
+    return true;
+  } catch (err) {
+    debugLog({ kind: "hydration.error", sessionID: currentSessionID, error: String(err) });
+    return false;
+  }
+}
+
+async function safeReadAsync<Value>(read: () => Promise<Value>): Promise<Value | undefined> {
+  try {
+    return await read();
+  } catch {
+    return undefined;
+  }
+}
+
+function summarizeAssistantMessages(messages: unknown[]): {
+  completedAt?: string;
+  hasError: boolean;
+} {
+  let completedAt: string | undefined;
+  let hasError = false;
+  const assistantMessages = messages
+    .map((rawMessage) => asRecord(rawMessage))
+    .map((message) => asRecord(message?.info))
+    .filter(
+      (info): info is Record<string, unknown> => info?.role === "assistant",
+    )
+    .sort((left, right) => messageTimeMillis(left) - messageTimeMillis(right));
+
+  for (const info of assistantMessages) {
+    const time = asRecord(info.time);
+    const candidate = timestampFromUnknown(time?.completed);
+    if (info.error) {
+      hasError = true;
+    } else if (candidate) {
+      completedAt = candidate;
+      hasError = false;
+    }
+  }
+
+  return { completedAt, hasError };
+}
+
+function messageTimeMillis(info: Record<string, unknown> | undefined): number {
+  const time = asRecord(info?.time);
+  return (
+    timestampMillisFromUnknown(time?.completed) ??
+    timestampMillisFromUnknown(time?.updated) ??
+    timestampMillisFromUnknown(time?.created) ??
+    0
+  );
+}
+
+function sessionTimestamp(session: Record<string, unknown>, key: string): string | undefined {
+  const time = asRecord(session.time);
+  return timestampFromUnknown(time?.[key]);
+}
+
+function timestampFromUnknown(value: unknown): string | undefined {
+  const millis = timestampMillisFromUnknown(value);
+  return millis === undefined ? undefined : new Date(millis).toISOString();
+}
+
+function timestampMillisFromUnknown(value: unknown): number | undefined {
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? undefined : parsed;
+  }
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    const millis = value < 10_000_000_000 ? value * 1000 : value;
+    const parsed = new Date(millis);
+    return Number.isNaN(parsed.getTime()) ? undefined : millis;
+  }
+  return undefined;
+}
+
 const tui: TuiPlugin = async (api: TuiPluginApi) => {
   const statePath = resolveStatePath();
   const textPath = resolveTextPath(statePath);
   const [state, setState] = createSignal<StatuslineState>(createEmptyState());
   const [nowMs, setNowMs] = createSignal(Date.now());
+  const [hydratedSessions, setHydratedSessions] = createSignal<Set<string>>(new Set());
+  const [hydratingSessions, setHydratingSessions] = createSignal<Set<string>>(new Set());
+  const [hydrateRetryTick, setHydrateRetryTick] = createSignal(0);
+
+  createEffect(() => {
+    hydrateRetryTick();
+    const route = api.route.current;
+    if (route.name === "session" && typeof route.params?.sessionID === "string") {
+      const sessionID = route.params.sessionID;
+      if (hydratedSessions().has(sessionID) || hydratingSessions().has(sessionID)) {
+        return;
+      }
+
+      setHydratingSessions((prev) => {
+        const next = new Set(prev);
+        next.add(sessionID);
+        return next;
+      });
+
+      void (async () => {
+        const hydrated = await hydratePreviousSubagents(
+          api,
+          sessionID,
+          statePath,
+          textPath,
+          setState,
+        );
+        setHydratingSessions((prev) => {
+          const next = new Set(prev);
+          next.delete(sessionID);
+          return next;
+        });
+        if (hydrated) {
+          setHydratedSessions((prev) => {
+            const next = new Set(prev);
+            next.add(sessionID);
+            return next;
+          });
+          return;
+        }
+        setTimeout(() => {
+          setHydrateRetryTick((value) => value + 1);
+        }, 1000);
+      })();
+    }
+  });
 
   const tick = setInterval(() => {
     setNowMs(Date.now());
@@ -701,6 +973,7 @@ const tui: TuiPlugin = async (api: TuiPluginApi) => {
 
   const disposers = [
     api.event.on("session.created", applyEvent),
+    api.event.on("session.updated", applyEvent),
     api.event.on("session.idle", applyEvent),
     api.event.on("session.error", applyEvent),
     api.event.on("message.updated", applyEvent),

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -33,6 +33,9 @@ const MIN_ROW_WIDTH = 24;
 const MIN_LABEL_WIDTH = 8;
 const DONE_TOKEN_REHYDRATE_THROTTLE_MS = 2000;
 const DONE_TOKEN_REHYDRATE_MAX_ATTEMPTS = 15;
+const HYDRATE_RETRY_BASE_DELAY_MS = 1000;
+const HYDRATE_RETRY_MAX_DELAY_MS = 30_000;
+const HYDRATE_RETRY_MAX_ATTEMPTS = 6;
 const CLOCK_ICON = "";
 const TOKEN_ICON = "";
 
@@ -673,6 +676,7 @@ async function hydratePreviousSubagents(
     const directory = api.state.path.directory;
     const sessionClient = api.client.session;
     let topLevelHydrationFailed = false;
+    let statusHydrationFailed = false;
 
     const [childrenResp, messagesResp, statusResp] = await Promise.all([
       (async () => {
@@ -695,7 +699,10 @@ async function hydratePreviousSubagents(
         const response = await safeReadAsync(() =>
           sessionClient?.status?.({ directory }) ?? Promise.resolve({ data: {} }),
         );
-        if (!response) topLevelHydrationFailed = true;
+        if (!response) {
+          topLevelHydrationFailed = true;
+          statusHydrationFailed = true;
+        }
         return response;
       })(),
     ]);
@@ -709,30 +716,33 @@ async function hydratePreviousSubagents(
         const session = asRecord(child);
         const childID = typeof session?.id === "string" ? session.id : undefined;
         if (!childID) {
-          return { childID: undefined, completedAt: undefined, hasError: false };
+          return {
+            childID: undefined,
+            completedAt: undefined,
+            evidenceAt: undefined,
+            hasError: false,
+            fetchFailed: false,
+          };
         }
         const childMessagesResp = await safeReadAsync(() =>
           sessionClient?.messages?.({ sessionID: childID, directory }) ??
             Promise.resolve({ data: [] }),
         );
+        let fetchFailed = false;
         if (!childMessagesResp) {
           childHydrationFailed = true;
+          fetchFailed = true;
         }
         const childMessages = Array.isArray(childMessagesResp?.data)
           ? childMessagesResp.data
           : [];
-        return { childID, ...summarizeAssistantMessages(childMessages) };
+        return { childID, ...summarizeAssistantMessages(childMessages), fetchFailed };
       }),
     );
-    const childErrors = new Set(
+    const childMessageSummaryByID = new Map(
       childMessageResults
-        .filter((result) => result.childID && result.hasError)
-        .map((result) => result.childID as string),
-    );
-    const childCompletedAt = new Map(
-      childMessageResults
-        .filter((result) => result.childID && result.completedAt)
-        .map((result) => [result.childID as string, result.completedAt as string]),
+        .filter((result) => result.childID)
+        .map((result) => [result.childID as string, result]),
     );
 
     setState((current) => {
@@ -752,11 +762,26 @@ async function hydratePreviousSubagents(
         if (applySubagentEvent(next, fakeEvent)) changed = true;
 
         const status = asRecord(allStatuses[session.id]);
-        const isBusy = status?.type === "busy";
-        const endedAt = childCompletedAt.get(session.id) ?? sessionTimestamp(session, "updated");
-        if (!isBusy && endedAt) {
-          const childStatus = childErrors.has(session.id) ? "error" : "done";
-          if (markChildStatus(next, session.id, childStatus, endedAt)) changed = true;
+        const sessionStatus = deriveSessionChildStatus(status);
+        const childSummary = childMessageSummaryByID.get(session.id);
+        const explicitCompletionEvidence =
+          !!childSummary &&
+          !childSummary.fetchFailed &&
+          (typeof childSummary.completedAt === "string" || childSummary.hasError);
+        const fallbackEndedAt = childSummary?.completedAt ?? childSummary?.evidenceAt;
+        const statusEndedAt =
+          fallbackEndedAt ??
+          sessionTimestamp(session, "completed") ??
+          sessionTimestamp(session, "updated");
+
+        if (sessionStatus === "done" || sessionStatus === "error") {
+          if (markChildStatus(next, session.id, sessionStatus, statusEndedAt)) changed = true;
+          continue;
+        }
+
+        if (!sessionStatus && !statusHydrationFailed && explicitCompletionEvidence) {
+          const childStatus = childSummary?.hasError ? "error" : "done";
+          if (markChildStatus(next, session.id, childStatus, fallbackEndedAt)) changed = true;
         }
       }
 
@@ -824,11 +849,57 @@ async function safeReadAsync<Value>(read: () => Promise<Value>): Promise<Value |
   }
 }
 
+function normalizedSessionStatusValue(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function deriveSessionChildStatus(
+  status: Record<string, unknown> | undefined,
+): ChildSessionState["status"] | undefined {
+  if (!status) return undefined;
+
+  if (status.error) return "error";
+
+  const values = [
+    normalizedSessionStatusValue(status.type),
+    normalizedSessionStatusValue(status.status),
+    normalizedSessionStatusValue(status.state),
+    normalizedSessionStatusValue(status.phase),
+    normalizedSessionStatusValue(status.result),
+  ].filter((value): value is string => Boolean(value));
+
+  if (status.busy === true || status.running === true) {
+    values.push("busy");
+  }
+
+  if (
+    values.some((value) =>
+      ["error", "failed", "failure", "cancelled", "canceled", "aborted"].includes(value),
+    )
+  ) {
+    return "error";
+  }
+
+  if (values.some((value) => ["busy", "running", "pending", "queued", "in_progress"].includes(value))) {
+    return "running";
+  }
+
+  if (values.some((value) => ["done", "completed", "complete", "success", "succeeded", "idle"].includes(value))) {
+    return "done";
+  }
+
+  return undefined;
+}
+
 function summarizeAssistantMessages(messages: unknown[]): {
   completedAt?: string;
+  evidenceAt?: string;
   hasError: boolean;
 } {
   let completedAt: string | undefined;
+  let evidenceAt: string | undefined;
   let hasError = false;
   const assistantMessages = messages
     .map((rawMessage) => asRecord(rawMessage))
@@ -841,15 +912,21 @@ function summarizeAssistantMessages(messages: unknown[]): {
   for (const info of assistantMessages) {
     const time = asRecord(info.time);
     const candidate = timestampFromUnknown(time?.completed);
+    const errorAt =
+      timestampFromUnknown(time?.updated) ??
+      timestampFromUnknown(time?.completed) ??
+      timestampFromUnknown(time?.created);
     if (info.error) {
       hasError = true;
+      evidenceAt = errorAt ?? evidenceAt;
     } else if (candidate) {
       completedAt = candidate;
+      evidenceAt = candidate;
       hasError = false;
     }
   }
 
-  return { completedAt, hasError };
+  return { completedAt, evidenceAt, hasError };
 }
 
 function messageTimeMillis(info: Record<string, unknown> | undefined): number {
@@ -892,49 +969,147 @@ const tui: TuiPlugin = async (api: TuiPluginApi) => {
   const [nowMs, setNowMs] = createSignal(Date.now());
   const [hydratedSessions, setHydratedSessions] = createSignal<Set<string>>(new Set());
   const [hydratingSessions, setHydratingSessions] = createSignal<Set<string>>(new Set());
+  const [hydrateRetryPendingSessions, setHydrateRetryPendingSessions] = createSignal<Set<string>>(new Set());
+  const [hydrateRetryAttempts, setHydrateRetryAttempts] = createSignal<Map<string, number>>(new Map());
   const [hydrateRetryTick, setHydrateRetryTick] = createSignal(0);
+  const hydrateRetryTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
+  let disposed = false;
+  let previousRouteSessionID: string | undefined;
+
+  const clearHydrateRetryTimeout = (sessionID: string): void => {
+    const timeout = hydrateRetryTimeouts.get(sessionID);
+    if (timeout) {
+      clearTimeout(timeout);
+      hydrateRetryTimeouts.delete(sessionID);
+    }
+  };
+
+  const resetHydrateRetry = (sessionID: string | undefined): void => {
+    if (!sessionID) return;
+    clearHydrateRetryTimeout(sessionID);
+    setHydrateRetryPendingSessions((prev) => {
+      if (!prev.has(sessionID)) return prev;
+      const next = new Set(prev);
+      next.delete(sessionID);
+      return next;
+    });
+    setHydrateRetryAttempts((prev) => {
+      if (!prev.has(sessionID)) return prev;
+      const next = new Map(prev);
+      next.delete(sessionID);
+      return next;
+    });
+  };
 
   createEffect(() => {
     hydrateRetryTick();
     const route = api.route.current;
-    if (route.name === "session" && typeof route.params?.sessionID === "string") {
-      const sessionID = route.params.sessionID;
-      if (hydratedSessions().has(sessionID) || hydratingSessions().has(sessionID)) {
-        return;
-      }
+    const routeSessionID =
+      route.name === "session" && typeof route.params?.sessionID === "string"
+        ? route.params.sessionID
+        : undefined;
 
-      setHydratingSessions((prev) => {
-        const next = new Set(prev);
-        next.add(sessionID);
-        return next;
-      });
+    if (previousRouteSessionID && previousRouteSessionID !== routeSessionID) {
+      resetHydrateRetry(previousRouteSessionID);
+    }
+    previousRouteSessionID = routeSessionID;
 
-      void (async () => {
-        const hydrated = await hydratePreviousSubagents(
-          api,
-          sessionID,
-          statePath,
-          textPath,
-          setState,
-        );
+    if (!routeSessionID) return;
+
+    const sessionID = routeSessionID;
+    const currentAttempts = hydrateRetryAttempts().get(sessionID) ?? 0;
+    if (
+      currentAttempts >= HYDRATE_RETRY_MAX_ATTEMPTS ||
+      hydratedSessions().has(sessionID) ||
+      hydratingSessions().has(sessionID) ||
+      hydrateRetryPendingSessions().has(sessionID)
+    ) {
+      return;
+    }
+
+    setHydratingSessions((prev) => {
+      const next = new Set(prev);
+      next.add(sessionID);
+      return next;
+    });
+
+    void (async () => {
+      const finishHydrating = (): void => {
         setHydratingSessions((prev) => {
           const next = new Set(prev);
           next.delete(sessionID);
           return next;
         });
-        if (hydrated) {
-          setHydratedSessions((prev) => {
-            const next = new Set(prev);
-            next.add(sessionID);
-            return next;
-          });
-          return;
-        }
-        setTimeout(() => {
-          setHydrateRetryTick((value) => value + 1);
-        }, 1000);
-      })();
-    }
+      };
+
+      const hydrated = await hydratePreviousSubagents(
+        api,
+        sessionID,
+        statePath,
+        textPath,
+        setState,
+      );
+      if (disposed) {
+        clearHydrateRetryTimeout(sessionID);
+        finishHydrating();
+        return;
+      }
+      if (hydrated) {
+        resetHydrateRetry(sessionID);
+        setHydratedSessions((prev) => {
+          const next = new Set(prev);
+          next.add(sessionID);
+          return next;
+        });
+        finishHydrating();
+        return;
+      }
+
+      const attempts = hydrateRetryAttempts().get(sessionID) ?? 0;
+      if (attempts >= HYDRATE_RETRY_MAX_ATTEMPTS) {
+        setHydrateRetryPendingSessions((prev) => {
+          if (!prev.has(sessionID)) return prev;
+          const next = new Set(prev);
+          next.delete(sessionID);
+          return next;
+        });
+        clearHydrateRetryTimeout(sessionID);
+        finishHydrating();
+        return;
+      }
+
+      const delayMs = Math.min(
+        HYDRATE_RETRY_MAX_DELAY_MS,
+        HYDRATE_RETRY_BASE_DELAY_MS * 2 ** attempts,
+      );
+
+      setHydrateRetryAttempts((prev) => {
+        const next = new Map(prev);
+        next.set(sessionID, attempts + 1);
+        return next;
+      });
+
+      setHydrateRetryPendingSessions((prev) => {
+        const next = new Set(prev);
+        next.add(sessionID);
+        return next;
+      });
+      finishHydrating();
+
+      clearHydrateRetryTimeout(sessionID);
+      const timeout = setTimeout(() => {
+        hydrateRetryTimeouts.delete(sessionID);
+        setHydrateRetryPendingSessions((prev) => {
+          if (!prev.has(sessionID)) return prev;
+          const next = new Set(prev);
+          next.delete(sessionID);
+          return next;
+        });
+        if (disposed) return;
+        setHydrateRetryTick((value) => value + 1);
+      }, delayMs);
+      hydrateRetryTimeouts.set(sessionID, timeout);
+    })();
   });
 
   const tick = setInterval(() => {
@@ -981,7 +1156,12 @@ const tui: TuiPlugin = async (api: TuiPluginApi) => {
   ];
 
   api.lifecycle.onDispose(() => {
+    disposed = true;
     clearInterval(tick);
+    for (const timeout of hydrateRetryTimeouts.values()) {
+      clearTimeout(timeout);
+    }
+    hydrateRetryTimeouts.clear();
     for (const dispose of disposers) {
       dispose();
     }


### PR DESCRIPTION
## Summary
- Reconstructs previously executed subagents when opening an existing OpenCode session instead of starting the sidebar state empty.
- Uses persisted child sessions as the primary source and parent message parts as complementary context for subtasks/delegate wrappers.
- Preserves live monitoring behavior while fixing historical elapsed times with real completion/update timestamps.

## Why this approach
OpenCode can reopen old sessions with their chat history and child/subagent context, so the plugin should hydrate from OpenCode's persisted session model instead of relying only on live events. The implementation uses `api.client.session.children(...)` as the authoritative source for real child sessions and scans parent `message.parts` to recover subtask/tool metadata such as titles, agents, message IDs, and completion timestamps.

This keeps the live event path intact: new subagents are still handled by the existing `message.part.updated`, `session.created`, `session.idle`, and `session.error` event flow. Historical hydration only runs when entering a session route, merges into the current state, and persists the same snapshot format already used by the plugin.

## Implementation details
- Adds TUI hydration for previous subagents on session route entry.
- Reads child sessions, parent messages, and session status through the OpenCode client.
- Replays historical session/message data through the existing event/state helpers to avoid creating a separate state model.
- Backfills missing `messageID` on historical parts from the parent message when needed.
- Uses child assistant message completion or session update timestamps to compute historical durations.
- Avoids finalizing sessions that OpenCode explicitly reports as `busy`.
- Retries hydration if any top-level or child-message fetch fails, instead of marking the session permanently hydrated.
- Adds `session.updated` handling so metadata updates can refresh child session information.

## Validation
- `pnpm typecheck`
- `pnpm build`
- Manual TUI checks:
  - old sessions now show previous subagents
  - completed historical subagents no longer show inflated multi-hour durations
  - newly launched subagents still appear in the sidebar with duration/tokens

## Notes
- No package/config files were changed.
- The runtime/statusline path remains based on the existing `applySubagentEvent` flow.