### PR TITLE
ci: pass npm token to node auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,4 +43,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: pnpm exec semantic-release


### PR DESCRIPTION
Closes #8

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Pass the npm repository secret as `NODE_AUTH_TOKEN` during semantic-release.
- Keep `NPM_TOKEN` available for `@semantic-release/npm` while satisfying npm's `.npmrc` auth lookup.

## Changes
| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Adds `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` to the Release step. |

## Test Plan
- [x] Verified failed Release logs showed npm reading setup-node `.npmrc`
- [x] Verified npm token works locally with `NODE_AUTH_TOKEN`
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts / not applicable: no shell scripts modified
- [x] Skills tested in at least one agent / not applicable: no skills modified
- [x] Docs updated if behavior changed / not applicable
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers