### PR TITLE
fix: add order field to sidebar_content slot for predictable positioning

### DIFF
--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -1216,6 +1216,7 @@ const tui: TuiPlugin = async (api: TuiPluginApi) => {
   });
 
   api.slots.register({
+    order: 90,
     slots: {
       sidebar_content(ctx: SidebarContentContext) {
         const routeSessionID =


### PR DESCRIPTION
## Problem
Currently, `sub-agent-statusline` registers its `sidebar_content` slot without an explicit `order` field. In OpenCode's slot system, omitting `order` assigns an implicit minimum priority that positions the component **above** plugins that do define a numeric `order`.
This causes the subagent monitor to render on top of visual/branding plugins that use `order: 50` (e.g., sidebar ASCII artwork), which is visually incorrect — decorative elements should sit above functional monitors.
## Solution
Add `order: 90` to the `sidebar_content` slot registration.
## Why 90?
OpenCode's built-in sidebar tabs follow a convention of multiples of 100:
| Built-in Plugin | `order` |
|-----------------|---------|
| Context         | 100     |
| MCP             | 200     |
| LSP             | 300     |
| Todo            | 400     |
| Files           | 500     |
The value `90` was chosen to:
1. **Stay below decorative plugins** (typically `order: 50–89`) — ASCII art, logos, branding
2. **Stay above built-in tabs** (`order: 100+`) — ensuring the monitor remains visible near the top without mixing into the standard tab list
3. **Leave room for coexistence** — other visual plugins can use 50–89 without conflict
## Impact
This change makes `sub-agent-statusline` a well-behaved citizen in multi-plugin environments. External plugins that define `order` will no longer have their visual elements unexpectedly covered by the subagent monitor.
## References
- OpenCode slot ordering spec: https://github.com/anomalyco/opencode/blob/dev/packages/opencode/specs/tui-plugins.md
- Context7 documentation for `/anomalyco/opencode` (TuiSlotPlugin ordering behavior)