### PR TITLE
docs: add community and security guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+about: Report something that is broken or incorrect
+title: "bug: "
+labels: [bug]
+assignees: []
+---
+
+## Summary
+
+Describe the bug clearly.
+
+## Steps to Reproduce
+
+1. 
+2. 
+3. 
+
+## Expected Behavior
+
+What should have happened?
+
+## Actual Behavior
+
+What happened instead?
+
+## Environment
+
+- OS:
+- Node.js version:
+- pnpm version:
+- package version / commit:
+
+## Additional Context
+
+Logs, screenshots, and related details.
+
+> Security note: if this may be a vulnerability, do **not** file a public issue.
+> Please use private reporting described in `SECURITY.md`.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an improvement or new capability
+title: "feat: "
+labels: [enhancement]
+assignees: []
+---
+
+## Problem
+
+What problem are you trying to solve?
+
+## Proposed Solution
+
+Describe your proposed change.
+
+## Alternatives Considered
+
+What other options did you evaluate?
+
+## Additional Context
+
+Links, mockups, references, or examples.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Summary
+
+<!-- What changed and why? -->
+
+## Validation
+
+<!-- What did you run locally? -->
+
+## Checklist
+
+- [ ] I used a Conventional Commit title (e.g. `fix: ...`, `feat: ...`, `docs: ...`)
+- [ ] I linked related issue(s), or explained why none are needed
+- [ ] I did not include secrets, credentials, or private data
+- [ ] I called out any security-sensitive behavior changes
+- [ ] I updated docs when behavior or usage changed

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,124 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+joaquinvesapa@gmail.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,76 @@
+# Contributing
+
+Thanks for your interest in contributing to `opencode-subagent-statusline` ❤️
+
+We aim to keep contributions simple, respectful, and easy to review.
+
+## Before You Start
+
+- Please check existing issues/PRs to avoid duplicate work.
+- Prefer an issue-first workflow for non-trivial changes (bugfixes/features).
+- For tiny docs fixes, feel free to open a PR directly.
+
+## Local Setup
+
+### Requirements
+
+- Node.js 20+
+- pnpm 9+
+
+### Install
+
+```sh
+pnpm install
+```
+
+## Development Flow
+
+1. Fork the repository
+2. Create a branch from `main`
+3. Make your changes in small, reviewable commits
+4. Open a pull request with context and rationale
+
+Branch naming suggestions:
+
+- `feat/<short-description>`
+- `fix/<short-description>`
+- `docs/<short-description>`
+
+## Commit Messages
+
+Use **Conventional Commits**:
+
+- `feat: add runtime summary grouping`
+- `fix: handle missing token metadata`
+- `docs: clarify local setup`
+
+## Quality Checks
+
+Run what exists in this repository before opening a PR:
+
+```sh
+pnpm typecheck
+```
+
+If additional test scripts are introduced, please run them as well.
+
+## Security & Secrets
+
+- Never commit secrets, tokens, API keys, or private credentials.
+- If your change touches security-sensitive behavior, mention it clearly in the PR.
+- For vulnerabilities, follow [SECURITY.md](./SECURITY.md).
+
+## Pull Requests
+
+Please include:
+
+- what changed
+- why it changed
+- how you validated it locally
+- screenshots/log snippets when UI or behavior changes are involved
+
+Keep PRs focused. Smaller PRs get reviewed faster and with better feedback.
+
+## Code of Conduct
+
+By participating, you agree to follow the [Code of Conduct](./CODE_OF_CONDUCT.md).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Joaquin Vesco Aparicio
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Supported Versions
+
+We only support the latest published version of this project with security updates.
+
+| Version | Supported |
+| ------- | --------- |
+| Latest  | ✅ |
+| Older   | ❌ |
+
+## Reporting a Vulnerability
+
+Please **do not open public GitHub issues** for suspected vulnerabilities.
+
+Use this order for reporting:
+
+1. **Preferred:** GitHub Security Advisories / Private Vulnerability Reporting for this repository
+2. **Fallback:** email <joaquinvesapa@gmail.com>
+
+Include as much detail as possible:
+
+- affected version/commit
+- impact and severity estimate
+- reproduction steps or proof of concept
+- any suggested mitigation
+
+## Response Timeline
+
+We will try to:
+
+- acknowledge your report within **3 business days**
+- provide an initial assessment within **7 business days**
+- share remediation status updates regularly until resolution
+
+Timelines may vary based on report complexity and maintainer availability.


### PR DESCRIPTION
## Summary
- Add MIT license, security policy, contributing guide, and Contributor Covenant code of conduct.
- Add lightweight bug, feature, and pull request templates for safer community contributions.
- Document private vulnerability reporting with email fallback.

## Notes
- Dependabot and CodeQL are intentionally deferred for now.