### PR TITLE
fix: avoid sqlite json functions for token hydration

### DIFF
--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -152,12 +152,15 @@ function readDoneTokensFromOpenCodeDb(sessionID: string): ChildTokenState | unde
   const dbPath = resolveOpenCodeDbPath();
   if (!existsSync(dbPath)) return undefined;
 
+  // Keep JSON parsing in TypeScript instead of relying on sqlite JSON functions.
+  // Some sqlite3 builds, especially on WSL/Linux distributions, are compiled
+  // without JSON support and fail with `no such function json_extract`.
   const output = safeRead(() =>
     execFileSync(
       "sqlite3",
       [
         dbPath,
-        `select data from message where session_id='${escapeSqlString(sessionID)}' and json_extract(data, '$.tokens.total') is not null order by time_created desc;`,
+        `select data from message where session_id='${escapeSqlString(sessionID)}' order by time_created desc limit 50;`,
       ],
       { encoding: "utf8", timeout: 1000, maxBuffer: 1024 * 1024 },
     ),


### PR DESCRIPTION
## Summary

- Avoid sqlite JSON functions when hydrating token data from the OpenCode database.
- Parse message JSON in TypeScript so sqlite builds without JSON support do not fail with `no such function json_extract`.

Closes #13

## Validation

- [x] Manually tested the affected flow; it worked, so this should be fixed.
- [x] Reviewed the diff locally.
- [x] Shellcheck not applicable; no shell scripts changed.

## Checklist

- [x] I used a Conventional Commit title (e.g. `fix: ...`, `feat: ...`, `docs: ...`)
- [x] I linked related issue(s), or explained why none are needed
- [x] I did not include secrets, credentials, or private data
- [x] I called out any security-sensitive behavior changes
- [x] I updated docs when behavior or usage changed