### PR TITLE
fix(tui): stabilize subagent sidebar scroll

### DIFF
--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -49,7 +49,7 @@ const SUBAGENTS_SECTION_ENABLED_KV_KEY = "subagents.sidebar.enabled";
 const SUBAGENTS_VISIBLE_ROWS = 5;
 const SUBAGENTS_ROW_HEIGHT = 3;
 const SUBAGENTS_ROW_GAP = 1;
-const SUBAGENTS_LIST_HEIGHT =
+const SUBAGENTS_MAX_LIST_HEIGHT =
   SUBAGENTS_VISIBLE_ROWS * SUBAGENTS_ROW_HEIGHT +
   (SUBAGENTS_VISIBLE_ROWS - 1) * SUBAGENTS_ROW_GAP;
 const INACTIVE_SUBAGENT_OPACITY = 0.65;
@@ -706,6 +706,20 @@ function SidebarSubagents(props: {
     return result;
   });
 
+  const visibleChildren = createMemo(() => {
+    const ownChildren = children();
+    if (ownChildren.length > 0) return ownChildren;
+    return otherChildren();
+  });
+
+  const showingOtherSessions = createMemo(
+    () => children().length === 0 && otherChildren().length > 0,
+  );
+
+  const shouldScroll = createMemo(
+    () => visibleChildren().length > SUBAGENTS_VISIBLE_ROWS,
+  );
+
   const ChildRow = (rowProps: { child: ChildSessionState }) => {
     const child = () => rowProps.child;
     const [hovered, setHovered] = createSignal(false);
@@ -806,20 +820,30 @@ function SidebarSubagents(props: {
       <AggregateBar />
 
       <Show when={props.expanded()}>
-        <scrollbox height={SUBAGENTS_LIST_HEIGHT} scrollY>
-          <box flexDirection="column" rowGap={SUBAGENTS_ROW_GAP}>
-            <For each={children()}>
-              {(child: ChildSessionState) => <ChildRow child={child} />}
-            </For>
-
-            <Show when={children().length === 0 && otherChildren().length > 0}>
-              <text fg={props.theme.textMuted}>Other sessions</text>
-              <For each={otherChildren()}>
+        <Show
+          when={shouldScroll()}
+          fallback={
+            <box flexDirection="column" rowGap={SUBAGENTS_ROW_GAP}>
+              <Show when={showingOtherSessions()}>
+                <text fg={props.theme.textMuted}>Other sessions</text>
+              </Show>
+              <For each={visibleChildren()}>
                 {(child: ChildSessionState) => <ChildRow child={child} />}
               </For>
-            </Show>
-          </box>
-        </scrollbox>
+            </box>
+          }
+        >
+          <scrollbox height={SUBAGENTS_MAX_LIST_HEIGHT} scrollY>
+            <box flexDirection="column" rowGap={SUBAGENTS_ROW_GAP}>
+              <Show when={showingOtherSessions()}>
+                <text fg={props.theme.textMuted}>Other sessions</text>
+              </Show>
+              <For each={visibleChildren()}>
+                {(child: ChildSessionState) => <ChildRow child={child} />}
+              </For>
+            </box>
+          </scrollbox>
+        </Show>
       </Show>
     </box>
   );


### PR DESCRIPTION
Closes #21

## Type
- [x] Bug fix

## Summary
- Prevents the subagent sidebar from reserving fixed scroll height when empty or under capacity.
- Keeps the list growing naturally through 5 visible agents and enables scrolling only from the 6th onward.
- Avoids unnecessary scrollbox rendering for small lists to reduce scrollbar flicker.

## Changes
| File | Change |
|------|--------|
| `src/tui.tsx` | Reworked subagent list height/scroll behavior with conditional scrollbox usage. |

## Test Plan
- [x] `pnpm run typecheck`
- [x] Manually tested with 5 temporary sub-agents

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran relevant verification
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers