### PR TITLE
fix(tui): collapse planned subagent work items

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -83,6 +83,27 @@ function firstDistinctSummary(
   return undefined;
 }
 
+function isTechnicalDelegationTitle(value: string | undefined): boolean {
+  if (!value) return false;
+  return /^delegation:\s+/i.test(value.trim());
+}
+
+function promptTitle(value: unknown): string | undefined {
+  const text = conciseText(value);
+  if (!text) return undefined;
+  const sentence = text.match(/^(.+?[.!?])\s/)?.[1]?.trim();
+  const title = sentence && sentence.length <= 100 ? sentence : text;
+  return title.length > 100 ? `${title.slice(0, 99)}…` : title;
+}
+
+function firstUsefulTitle(candidates: unknown[]): string | undefined {
+  for (const candidate of candidates) {
+    const title = promptTitle(candidate);
+    if (title && !isTechnicalDelegationTitle(title)) return title;
+  }
+  return undefined;
+}
+
 export function extractCreatedChild(event: EventLike): {
   id: string;
   title: string;
@@ -309,7 +330,13 @@ function extractToolChild(event: EventLike): ToolChild | null {
   const input = isRecord(state.input) ? state.input : {};
   const description = asString(input.description);
   const subagentType = asString(input.subagent_type);
-  const title = asString(state.title) || description || subagentType || tool;
+  const rawTitle = asString(state.title);
+  const title =
+    (isTechnicalDelegationTitle(rawTitle) ? undefined : rawTitle) ||
+    description ||
+    firstUsefulTitle([input.prompt, part.description, state.description]) ||
+    subagentType ||
+    tool;
   const summary = firstDistinctSummary(
     [input.prompt, input.description, part.description, state.description],
     title,
@@ -451,6 +478,14 @@ export function extractChildDetails(event: EventLike): {
     ],
     details.title,
   );
+  if (isTechnicalDelegationTitle(details.title)) {
+    const replacementTitle =
+      asString(partInput?.description) ??
+      firstUsefulTitle([partInput?.prompt, part?.description, partState?.description]);
+    if (replacementTitle) {
+      details.title = replacementTitle;
+    }
+  }
 
   const tokenHints: ChildTokenState = {};
   const visited = new Set<object>();

--- a/src/render.ts
+++ b/src/render.ts
@@ -145,18 +145,142 @@ export function byPriority(a: ChildSessionState, b: ChildSessionState): number {
   return a.id.localeCompare(b.id);
 }
 
-export function renderStatusLine(state: StatuslineState): string {
-  const allChildren = Object.values(state.children);
-  const hasMatchingSubtask = (child: ChildSessionState): boolean =>
-    child.source === "tool" &&
-    allChildren.some(
-      (candidate) =>
-        candidate.source === "subtask" &&
-        candidate.parentID === child.parentID &&
-        candidate.messageID === child.messageID,
-    );
+const RECENT_DONE_VISIBLE_MS = 10 * 60 * 1000;
 
-  const children = allChildren.filter((child) => !hasMatchingSubtask(child)).sort(byPriority);
+function normalizeWorkItemTitle(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/\s*\([^)]*\)\s*/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function relatedWorkItemTitles(a: string, b: string): boolean {
+  const left = normalizeWorkItemTitle(a);
+  const right = normalizeWorkItemTitle(b);
+  if (!left || !right) return false;
+  return left.includes(right) || right.includes(left);
+}
+
+function sameAgentName(a: string | undefined, b: string | undefined): boolean {
+  if (!a || !b) return true;
+  return normalizeWorkItemTitle(a) === normalizeWorkItemTitle(b);
+}
+
+function isGenericToolWrapper(child: ChildSessionState): boolean {
+  if (child.source !== "tool") return false;
+  const title = normalizeWorkItemTitle(child.title);
+  return title === "delegate" || title === "task";
+}
+
+function sessionMatchesSynthetic(
+  session: ChildSessionState,
+  synthetic: ChildSessionState,
+): boolean {
+  if (session.source !== "session" && !session.id.startsWith("ses_")) return false;
+  if (session.parentID !== synthetic.parentID) return false;
+  if (synthetic.targetSessionID === session.id) return true;
+  if (session.targetSessionID === synthetic.id) return true;
+  if (
+    synthetic.messageID &&
+    session.messageID &&
+    synthetic.messageID === session.messageID
+  ) {
+    return true;
+  }
+  return (
+    sameAgentName(session.agentName, synthetic.agentName) &&
+    relatedWorkItemTitles(session.title, synthetic.title)
+  );
+}
+
+function mergeSyntheticWithSession(
+  synthetic: ChildSessionState,
+  session: ChildSessionState | undefined,
+): ChildSessionState {
+  if (!session) return synthetic;
+  return {
+    ...synthetic,
+    status: session.status,
+    color: session.color,
+    startedAt: session.startedAt ?? synthetic.startedAt,
+    updatedAt: session.updatedAt ?? synthetic.updatedAt,
+    endedAt: session.endedAt ?? synthetic.endedAt,
+    elapsedMs: session.elapsedMs ?? synthetic.elapsedMs,
+    tokens: session.tokens ?? synthetic.tokens,
+    targetSessionID: session.id,
+    agentName: synthetic.agentName ?? session.agentName,
+  };
+}
+
+export function collapseSubagentWorkItems(
+  children: ChildSessionState[],
+): ChildSessionState[] {
+  const syntheticChildren = children.filter(
+    (child) => child.source === "tool" || child.source === "subtask",
+  );
+  const sessionBySyntheticID = new Map<string, ChildSessionState>();
+
+  for (const synthetic of syntheticChildren) {
+    const matchingSessions = children.filter((candidate) =>
+      sessionMatchesSynthetic(candidate, synthetic),
+    );
+    if (matchingSessions.length > 0) {
+      sessionBySyntheticID.set(synthetic.id, matchingSessions.sort(byPriority)[0]);
+    }
+  }
+
+  return children
+    .filter((child) => {
+      if (child.source === "session") {
+        return !syntheticChildren.some(
+          (synthetic) =>
+            synthetic.targetSessionID === child.id ||
+            (synthetic.parentID === child.parentID &&
+              synthetic.messageID &&
+              synthetic.messageID === child.messageID) ||
+            sessionMatchesSynthetic(child, synthetic),
+        );
+      }
+
+      if (child.source !== "tool") return true;
+      if (isGenericToolWrapper(child)) {
+        return !syntheticChildren.some(
+          (synthetic) =>
+            synthetic.id !== child.id && synthetic.parentID === child.parentID,
+        );
+      }
+      return !syntheticChildren.some(
+        (real) =>
+          real.id !== child.id &&
+          real.parentID === child.parentID &&
+          relatedWorkItemTitles(real.title, child.title),
+      );
+    })
+    .map((child) => mergeSyntheticWithSession(child, sessionBySyntheticID.get(child.id)));
+}
+
+export function isVisibleWorkItem(
+  child: ChildSessionState,
+  nowMs = Date.now(),
+): boolean {
+  if (child.status !== "done") return true;
+  const endedMs = Date.parse(child.endedAt ?? child.updatedAt);
+  if (Number.isNaN(endedMs)) return false;
+  return nowMs - endedMs <= RECENT_DONE_VISIBLE_MS;
+}
+
+export function visibleSubagentWorkItems(
+  children: ChildSessionState[],
+  nowMs = Date.now(),
+): ChildSessionState[] {
+  return collapseSubagentWorkItems(children).filter((child) =>
+    isVisibleWorkItem(child, nowMs),
+  );
+}
+
+export function renderStatusLine(state: StatuslineState): string {
+  const children = visibleSubagentWorkItems(Object.values(state.children)).sort(byPriority);
   const running = children.filter((c) => c.status === "running").length;
   const done = children.filter((c) => c.status === "done").length;
   const error = children.filter((c) => c.status === "error").length;

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -27,10 +27,16 @@ import {
 } from "solid-js";
 import type { Accessor } from "solid-js";
 import { applySubagentEvent, extractChildDetails } from "./events.js";
-import { byPriority, formatDuration, renderStatusLine } from "./render.js";
+import {
+  byPriority,
+  collapseSubagentWorkItems,
+  formatDuration,
+  isVisibleWorkItem,
+  renderStatusLine,
+  visibleSubagentWorkItems,
+} from "./render.js";
 import {
   createEmptyState,
-  getCounts,
   markChildStatus,
   resolveStatePath,
   resolveTextPath,
@@ -449,21 +455,6 @@ function statusColor(
   return theme.warning;
 }
 
-function normalizeTitle(value: string): string {
-  return value
-    .toLowerCase()
-    .replace(/\s*\([^)]*\)\s*/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-function relatedTitles(a: string, b: string): boolean {
-  const left = normalizeTitle(a);
-  const right = normalizeTitle(b);
-  if (!left || !right) return false;
-  return left.includes(right) || right.includes(left);
-}
-
 function isSessionTarget(value: unknown): value is string {
   return typeof value === "string" && value.startsWith("ses_");
 }
@@ -546,43 +537,10 @@ function navigateToSessionTarget(
   api.route.navigate("session", { sessionID: targetSessionID });
 }
 
-function isGenericToolWrapper(child: ChildSessionState): boolean {
-  if (child.source !== "tool") return false;
-  const title = normalizeTitle(child.title);
-  return title === "delegate" || title === "task";
-}
-
 function collapseToolWrappers(
   children: ChildSessionState[],
 ): ChildSessionState[] {
-  const syntheticChildren = children.filter(
-    (child) => child.source === "tool" || child.source === "subtask",
-  );
-  return children.filter((child) => {
-    if (child.source === "session") {
-      return !syntheticChildren.some(
-        (synthetic) =>
-          synthetic.targetSessionID === child.id ||
-          (synthetic.parentID === child.parentID &&
-            synthetic.messageID &&
-            synthetic.messageID === child.messageID),
-      );
-    }
-
-    if (child.source !== "tool") return true;
-    if (isGenericToolWrapper(child)) {
-      return !syntheticChildren.some(
-        (synthetic) =>
-          synthetic.id !== child.id && synthetic.parentID === child.parentID,
-      );
-    }
-    return !syntheticChildren.some(
-      (real) =>
-        real.id !== child.id &&
-        real.parentID === child.parentID &&
-        relatedTitles(real.title, child.title),
-    );
-  });
+  return collapseSubagentWorkItems(children);
 }
 
 function toFinitePositiveInt(value: unknown): number | undefined {
@@ -802,7 +760,9 @@ function SidebarSubagents(props: {
       Object.values(props.state().children).filter(
         (child) => child.parentID === props.sessionID,
       ),
-    ).sort(byPriority),
+    )
+      .filter((child) => isVisibleWorkItem(child, props.nowMs()))
+      .sort(byPriority),
   );
 
   const otherChildren = createMemo(() =>
@@ -810,7 +770,9 @@ function SidebarSubagents(props: {
       Object.values(props.state().children).filter(
         (child) => child.parentID !== props.sessionID,
       ),
-    ).sort(byPriority),
+    )
+      .filter((child) => isVisibleWorkItem(child, props.nowMs()))
+      .sort(byPriority),
   );
 
   const counts = createMemo(() => {
@@ -1029,7 +991,15 @@ function HomeBottomStatus(props: {
   state: () => StatuslineState;
   theme: TuiThemeCurrent;
 }) {
-  const counts = createMemo(() => getCounts(props.state()));
+  const counts = createMemo(() => {
+    const result = { running: 0, done: 0, error: 0 };
+    for (const child of visibleSubagentWorkItems(Object.values(props.state().children))) {
+      if (child.status === "running") result.running += 1;
+      if (child.status === "done") result.done += 1;
+      if (child.status === "error") result.error += 1;
+    }
+    return result;
+  });
   const visible = createMemo(() => counts().running > 0 || counts().error > 0);
 
   return (


### PR DESCRIPTION
## Summary

Closes #11.

- Treat a planned `tool`/`subtask` item plus its backing `ses_*` child session as one visible work item instead of two sidebar/statusline rows.
- Keep the planned task title as the user-facing label, but merge runtime data from the real session: status, elapsed time, token usage, and navigation target.
- Hide completed work items after a short 10-minute recent window while keeping running/error items visible.

## Context

I hit this locally with OpenCode emitting both of these for one logical subagent run:

```text
tool:* Implement Engram issue fixes
ses_*  Implement Engram issue fixes (@sdd-apply subagent)
```

The UI counted them as two running subagents even though the second entry was only the execution session for the planned task. I tested the same matching approach locally against my runtime state: 124 raw child entries collapsed to 62 logical work items, then old completed items were hidden by the recent-window filter.

## Validation

- [x] `corepack pnpm run typecheck`
- [x] Manually tested equivalent local patch against OpenCode runtime state

## Checklist

- [x] I used a Conventional Commit title (e.g. `fix: ...`, `feat: ...`, `docs: ...`)
- [x] I linked related issue(s), or explained why none are needed
- [x] I did not include secrets, credentials, or private data
- [x] I called out any security-sensitive behavior changes
- [ ] I updated docs when behavior or usage changed

Security-sensitive behavior changes: none.
Docs: not updated; this changes display/aggregation behavior rather than user configuration.