### PR TITLE
perf(tui): reduce subagent sidebar churn

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -354,9 +354,10 @@ export function renderStatusLine(state: StatuslineState): string {
   const running = children.filter((c) => c.status === "running").length;
   const done = children.filter((c) => c.status === "done").length;
   const error = children.filter((c) => c.status === "error").length;
+  const totalExecuted = formatNumber(state.totalExecuted ?? 0);
   const colorOn = colorsEnabled();
 
-  const aggregate = `↳ ${running} running · ${done} done · ${error} error`;
+  const aggregate = `↳ ${running} running · ${done} done · ${error} error · Σ ${totalExecuted} total`;
   if (children.length === 0) return aggregate;
 
   const details = children

--- a/src/render.ts
+++ b/src/render.ts
@@ -68,12 +68,12 @@ function formatTokenCount(total: number): string {
 function formatCompactTokenCount(total: number): string {
   const value = Math.max(0, total);
   if (value >= 1_000_000) {
-    return `${(value / 1_000_000).toFixed(1)}M tok`;
+    return `${(value / 1_000_000).toFixed(1)}M ctx`;
   }
   if (value >= 1_000) {
-    return `${(value / 1_000).toFixed(1)}k tok`;
+    return `${(value / 1_000).toFixed(1)}k ctx`;
   }
-  return `${Math.round(value)} tok`;
+  return `${Math.round(value)} ctx`;
 }
 
 function formatCompactPercentUsed(percent: number): string {
@@ -194,6 +194,18 @@ function sessionMatchesSynthetic(
   );
 }
 
+function messageKey(parentID: string, messageID: string): string {
+  return `${parentID}\0${messageID}`;
+}
+
+function betterPriority(
+  current: ChildSessionState | undefined,
+  candidate: ChildSessionState,
+): ChildSessionState {
+  if (!current) return candidate;
+  return byPriority(candidate, current) < 0 ? candidate : current;
+}
+
 function mergeSyntheticWithSession(
   synthetic: ChildSessionState,
   session: ChildSessionState | undefined,
@@ -216,46 +228,90 @@ function mergeSyntheticWithSession(
 export function collapseSubagentWorkItems(
   children: ChildSessionState[],
 ): ChildSessionState[] {
-  const syntheticChildren = children.filter(
-    (child) => child.source === "tool" || child.source === "subtask",
-  );
+  const syntheticChildren: ChildSessionState[] = [];
+  const syntheticByParentID = new Map<string, ChildSessionState[]>();
+  const sessionCandidatesByParentID = new Map<string, ChildSessionState[]>();
+  const hiddenTargetSessionIDs = new Set<string>();
+  const hiddenMessageKeys = new Set<string>();
+
+  for (const child of children) {
+    const isSynthetic = child.source === "tool" || child.source === "subtask";
+    if (isSynthetic) {
+      syntheticChildren.push(child);
+      const siblings = syntheticByParentID.get(child.parentID);
+      if (siblings) {
+        siblings.push(child);
+      } else {
+        syntheticByParentID.set(child.parentID, [child]);
+      }
+
+      if (child.targetSessionID) {
+        hiddenTargetSessionIDs.add(child.targetSessionID);
+      }
+      if (child.messageID) {
+        hiddenMessageKeys.add(messageKey(child.parentID, child.messageID));
+      }
+    }
+
+    if (child.source === "session" || child.id.startsWith("ses_")) {
+      const candidates = sessionCandidatesByParentID.get(child.parentID);
+      if (candidates) {
+        candidates.push(child);
+      } else {
+        sessionCandidatesByParentID.set(child.parentID, [child]);
+      }
+    }
+  }
+
   const sessionBySyntheticID = new Map<string, ChildSessionState>();
+  const hiddenMatchedSessionIDs = new Set<string>();
+  const hiddenSyntheticToolIDs = new Set<string>();
 
   for (const synthetic of syntheticChildren) {
-    const matchingSessions = children.filter((candidate) =>
-      sessionMatchesSynthetic(candidate, synthetic),
-    );
-    if (matchingSessions.length > 0) {
-      sessionBySyntheticID.set(synthetic.id, matchingSessions.sort(byPriority)[0]);
+    let bestSession: ChildSessionState | undefined;
+    for (const candidate of sessionCandidatesByParentID.get(synthetic.parentID) ?? []) {
+      if (!sessionMatchesSynthetic(candidate, synthetic)) continue;
+      bestSession = betterPriority(bestSession, candidate);
+      if (candidate.source === "session") {
+        hiddenMatchedSessionIDs.add(candidate.id);
+      }
+    }
+    if (bestSession) {
+      sessionBySyntheticID.set(synthetic.id, bestSession);
+    }
+  }
+
+  for (const siblings of syntheticByParentID.values()) {
+    for (const child of siblings) {
+      if (child.source !== "tool") continue;
+      if (isGenericToolWrapper(child)) {
+        if (siblings.length > 1) hiddenSyntheticToolIDs.add(child.id);
+        continue;
+      }
+
+      for (const sibling of siblings) {
+        if (sibling.id === child.id) continue;
+        if (relatedWorkItemTitles(sibling.title, child.title)) {
+          hiddenSyntheticToolIDs.add(child.id);
+          break;
+        }
+      }
     }
   }
 
   return children
     .filter((child) => {
       if (child.source === "session") {
-        return !syntheticChildren.some(
-          (synthetic) =>
-            synthetic.targetSessionID === child.id ||
-            (synthetic.parentID === child.parentID &&
-              synthetic.messageID &&
-              synthetic.messageID === child.messageID) ||
-            sessionMatchesSynthetic(child, synthetic),
+        return !(
+          hiddenTargetSessionIDs.has(child.id) ||
+          (child.messageID &&
+            hiddenMessageKeys.has(messageKey(child.parentID, child.messageID))) ||
+          hiddenMatchedSessionIDs.has(child.id)
         );
       }
 
       if (child.source !== "tool") return true;
-      if (isGenericToolWrapper(child)) {
-        return !syntheticChildren.some(
-          (synthetic) =>
-            synthetic.id !== child.id && synthetic.parentID === child.parentID,
-        );
-      }
-      return !syntheticChildren.some(
-        (real) =>
-          real.id !== child.id &&
-          real.parentID === child.parentID &&
-          relatedWorkItemTitles(real.title, child.title),
-      );
+      return !hiddenSyntheticToolIDs.has(child.id);
     })
     .map((child) => mergeSyntheticWithSession(child, sessionBySyntheticID.get(child.id)));
 }
@@ -274,9 +330,23 @@ export function visibleSubagentWorkItems(
   children: ChildSessionState[],
   nowMs = Date.now(),
 ): ChildSessionState[] {
-  return collapseSubagentWorkItems(children).filter((child) =>
+  const visible = collapseSubagentWorkItems(children).filter((child) =>
     isVisibleWorkItem(child, nowMs),
   );
+  const hasRunning = visible.some((child) => child.status === "running");
+  const activeMessageIDs = new Set(
+    visible
+      .filter((child) => child.status === "running" && child.messageID)
+      .map((child) => child.messageID as string),
+  );
+
+  if (!hasRunning) return visible;
+
+  return visible.filter((child) => {
+    if (child.status === "running" || child.status === "error") return true;
+    if (!child.messageID) return false;
+    return activeMessageIDs.has(child.messageID);
+  });
 }
 
 export function renderStatusLine(state: StatuslineState): string {

--- a/src/state.ts
+++ b/src/state.ts
@@ -40,6 +40,9 @@ export interface StatusCounts {
   error: number;
 }
 
+const TERMINAL_CHILD_TTL_MS = 60 * 60 * 1000;
+const MAX_TERMINAL_CHILDREN = 500;
+
 function statusColor(status: ChildStatus): ChildSessionState["color"] {
   if (status === "done") return "green";
   if (status === "error") return "red";
@@ -147,6 +150,45 @@ function resolveElapsedMs(child: ChildSessionState, nowMs: number): number {
   return Math.max(0, endMs - startedMs);
 }
 
+function terminalReferenceMs(child: ChildSessionState): number {
+  const parsed = Date.parse(child.endedAt ?? child.updatedAt ?? child.startedAt);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+export function pruneTerminalChildren(
+  state: StatuslineState,
+  now = new Date(),
+): number {
+  const nowMs = now.getTime();
+  const terminalChildren: Array<{ id: string; referenceMs: number }> = [];
+  let pruned = 0;
+
+  for (const child of Object.values(state.children)) {
+    if (child.status === "running") continue;
+
+    const referenceMs = terminalReferenceMs(child);
+    if (nowMs - referenceMs > TERMINAL_CHILD_TTL_MS) {
+      delete state.children[child.id];
+      pruned += 1;
+      continue;
+    }
+
+    terminalChildren.push({ id: child.id, referenceMs });
+  }
+
+  if (terminalChildren.length <= MAX_TERMINAL_CHILDREN) {
+    return pruned;
+  }
+
+  terminalChildren.sort((a, b) => b.referenceMs - a.referenceMs || a.id.localeCompare(b.id));
+  for (const child of terminalChildren.slice(MAX_TERMINAL_CHILDREN)) {
+    delete state.children[child.id];
+    pruned += 1;
+  }
+
+  return pruned;
+}
+
 export function refreshDerivedFields(
   state: StatuslineState,
   now = new Date(),
@@ -192,6 +234,9 @@ export function refreshDerivedFields(
   }
 
   state.updatedAt = safeTimestamp(state.updatedAt, nowISO);
+  if (pruneTerminalChildren(state, now) > 0) {
+    state.updatedAt = nowISO;
+  }
 }
 
 const STATUS_DIRNAME = "opencode-subagent-statusline";

--- a/src/state.ts
+++ b/src/state.ts
@@ -31,6 +31,8 @@ export interface ChildSessionState {
 
 export interface StatuslineState {
   children: Record<string, ChildSessionState>;
+  countedChildIDs: Record<string, true>;
+  totalExecuted: number;
   updatedAt: string;
 }
 
@@ -63,6 +65,63 @@ function toFiniteNumber(value: unknown): number | undefined {
     return Number.isFinite(parsed) ? parsed : undefined;
   }
   return undefined;
+}
+
+function toNonNegativeInteger(value: unknown): number | undefined {
+  const parsed = toFiniteNumber(value);
+  if (parsed === undefined) return undefined;
+  return Math.max(0, Math.floor(parsed));
+}
+
+function sanitizeCountedChildIDs(input: unknown): Record<string, true> {
+  if (!input || typeof input !== "object") return {};
+
+  const counted: Record<string, true> = {};
+  for (const [id, value] of Object.entries(input)) {
+    if (!id) continue;
+    if (value === true) {
+      counted[id] = true;
+    }
+  }
+  return counted;
+}
+
+function normalizeExecutionCounters(state: StatuslineState): void {
+  state.countedChildIDs = sanitizeCountedChildIDs(state.countedChildIDs);
+  const countedTotal = Object.keys(state.countedChildIDs).length;
+  state.totalExecuted = Math.max(
+    toNonNegativeInteger(state.totalExecuted) ?? 0,
+    countedTotal,
+  );
+}
+
+function isTechnicalDelegationTitle(value: string | undefined): boolean {
+  if (!value) return false;
+  return /^delegation:\s+/i.test(value.trim());
+}
+
+function isCountableWorkItem(child: Pick<ChildSessionState, "id" | "title"> &
+  Partial<Pick<ChildSessionState, "source">>): boolean {
+  if (child.source === "tool" || child.source === "subtask") return true;
+  if (child.source === "session" || child.id.startsWith("ses_")) {
+    return !isTechnicalDelegationTitle(child.title);
+  }
+  return true;
+}
+
+function countChildExecution(state: StatuslineState, child: Pick<ChildSessionState, "id" | "title"> &
+  Partial<Pick<ChildSessionState, "source">>): boolean {
+  if (!isCountableWorkItem(child)) return false;
+  normalizeExecutionCounters(state);
+  if (state.countedChildIDs[child.id]) return false;
+
+  const previousTotal = Math.max(
+    toNonNegativeInteger(state.totalExecuted) ?? 0,
+    Object.keys(state.countedChildIDs).length,
+  );
+  state.countedChildIDs[child.id] = true;
+  state.totalExecuted = previousTotal + 1;
+  return true;
 }
 
 function sanitizeTokens(input: unknown): ChildTokenState | undefined {
@@ -196,6 +255,8 @@ export function refreshDerivedFields(
   const nowISO = now.toISOString();
   const nowMs = now.getTime();
 
+  normalizeExecutionCounters(state);
+
   for (const [id, child] of Object.entries(state.children)) {
     const startedAt = safeTimestamp(child.startedAt, nowISO);
     const updatedAt = safeTimestamp(child.updatedAt, nowISO);
@@ -265,6 +326,8 @@ export function shouldPreserveStateOnStartup(): boolean {
 export function createEmptyState(): StatuslineState {
   return {
     children: {},
+    countedChildIDs: {},
+    totalExecuted: 0,
     updatedAt: new Date().toISOString(),
   };
 }
@@ -295,8 +358,25 @@ export async function loadState(statePath: string): Promise<StatuslineState> {
     const children =
       parsed.children && typeof parsed.children === "object" ? parsed.children : {};
 
+    const countedChildIDs = sanitizeCountedChildIDs(parsed.countedChildIDs);
+    for (const [id, child] of Object.entries(children)) {
+      const candidate = child as Partial<ChildSessionState>;
+      if (typeof candidate.title === "string" && isCountableWorkItem({
+        id,
+        title: candidate.title,
+        source: candidate.source,
+      })) {
+        countedChildIDs[id] = true;
+      }
+    }
+
     const state: StatuslineState = {
       children: children as Record<string, ChildSessionState>,
+      countedChildIDs,
+      totalExecuted: Math.max(
+        toNonNegativeInteger(parsed.totalExecuted) ?? 0,
+        Object.keys(countedChildIDs).length,
+      ),
       updatedAt:
         typeof parsed.updatedAt === "string"
           ? parsed.updatedAt
@@ -339,6 +419,13 @@ export function upsertRunningChild(
   const observedUpdatedAt = safeTimestamp(input.updatedAt, now);
   const observedStartedAt = safeTimestamp(input.startedAt, observedUpdatedAt);
   const existing = state.children[input.id];
+  const counted = existing
+    ? false
+    : countChildExecution(state, {
+        id: input.id,
+        title: input.title,
+        source: input.source,
+      });
   const targetSessionID = sanitizeTargetSessionID(
     input.targetSessionID ?? existing?.targetSessionID,
     input.id.startsWith("ses_") ? input.id : undefined,
@@ -380,7 +467,7 @@ export function upsertRunningChild(
     next.endedAt === existing.endedAt &&
     sameTokens(next.tokens, existing.tokens)
   ) {
-    return false;
+    return counted;
   }
 
   state.children[input.id] = next;

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -1031,7 +1031,8 @@ function SidebarSubagents(props: {
       <text fg={props.theme.success}>{`✓${counts().done} done`}</text>
       <text fg={props.theme.textMuted}> · </text>
       <text fg={props.theme.error}>{`✕${counts().error} err`}</text>
-      <text fg={props.theme.textMuted}>{` · Σ${totalExecuted()}`}</text>
+      <text fg={props.theme.textMuted}> · </text>
+      <text fg={props.theme.warning}>{`Σ${totalExecuted()}`}</text>
     </box>
   );
 
@@ -1094,7 +1095,8 @@ function HomeBottomStatus(props: {
           <text fg={props.theme.success}>{`✓ ${counts().done}`}</text>
           <text fg={props.theme.textMuted}> · </text>
           <text fg={props.theme.error}>{`✕ ${counts().error}`}</text>
-          <text fg={props.theme.textMuted}>{` · Σ ${totalExecuted()} total`}</text>
+          <text fg={props.theme.textMuted}> · </text>
+          <text fg={props.theme.warning}>{`Σ${totalExecuted()}`}</text>
         </box>
       </box>
     </Show>

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -36,6 +36,7 @@ import {
 import {
   createEmptyState,
   markChildStatus,
+  refreshDerivedFields,
   resolveStatePath,
   resolveTextPath,
   saveState,
@@ -432,6 +433,21 @@ function persistStateSnapshot(
   })();
 }
 
+function refreshLiveState(state: StatuslineState): boolean {
+  const beforeChildIDs = new Set(Object.keys(state.children));
+  refreshDerivedFields(state);
+
+  if (Object.keys(state.children).length !== beforeChildIDs.size) {
+    return true;
+  }
+
+  for (const childID of beforeChildIDs) {
+    if (!state.children[childID]) return true;
+  }
+
+  return false;
+}
+
 function elapsedMs(child: ChildSessionState, nowMs: number): number {
   if (child.status !== "running") {
     return child.elapsedMs ?? 0;
@@ -782,30 +798,21 @@ function SidebarSubagents(props: {
   sidebarWidth?: () => number | undefined;
   theme: TuiThemeCurrent;
 }) {
-  const activeOnly = (items: ChildSessionState[]): ChildSessionState[] => {
-    if (!items.some((child) => child.status === "running")) return items;
-    return items.filter((child) => child.status !== "done");
-  };
-
   const children = createMemo(() =>
-    activeOnly(
-      visibleSubagentWorkItems(
-        Object.values(props.state().children).filter(
-          (child) => child.parentID === props.sessionID,
-        ),
-        props.nowMs(),
+    visibleSubagentWorkItems(
+      Object.values(props.state().children).filter(
+        (child) => child.parentID === props.sessionID,
       ),
+      props.nowMs(),
     ).sort(byPriority),
   );
 
   const otherChildren = createMemo(() =>
-    activeOnly(
-      visibleSubagentWorkItems(
-        Object.values(props.state().children).filter(
-          (child) => child.parentID !== props.sessionID,
-        ),
-        props.nowMs(),
+    visibleSubagentWorkItems(
+      Object.values(props.state().children).filter(
+        (child) => child.parentID !== props.sessionID,
       ),
+      props.nowMs(),
     ).sort(byPriority),
   );
 
@@ -1298,7 +1305,8 @@ async function hydratePreviousSubagents(
         changed = true;
       }
 
-      if (!changed) return current;
+      const refreshed = refreshLiveState(next);
+      if (!changed && !refreshed) return current;
       persistStateSnapshot(statePath, textPath, next);
       return next;
     });
@@ -1663,7 +1671,9 @@ const tui: TuiPlugin = async (api: TuiPluginApi) => {
     setNowMs(Date.now());
     setState((current: StatuslineState) => {
       const next = cloneState(current);
-      if (!hydrateStateTokensFromTuiState(api, next)) return current;
+      const hydrated = hydrateStateTokensFromTuiState(api, next);
+      const refreshed = refreshLiveState(next);
+      if (!hydrated && !refreshed) return current;
       persistStateSnapshot(statePath, textPath, next);
       return next;
     });
@@ -1688,7 +1698,8 @@ const tui: TuiPlugin = async (api: TuiPluginApi) => {
           })),
         });
       }
-      if (!changed && !hydrated) return current;
+      const refreshed = refreshLiveState(next);
+      if (!changed && !hydrated && !refreshed) return current;
       persistStateSnapshot(statePath, textPath, next);
       return next;
     });

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -1026,13 +1026,13 @@ function SidebarSubagents(props: {
 
   const AggregateBar = () => (
     <box flexDirection="row" paddingRight={1}>
-      <text fg={props.theme.warning}>{`●${counts().running} run`}</text>
+      <text fg={props.theme.warning}>{`● ${counts().running} run`}</text>
       <text fg={props.theme.textMuted}> · </text>
-      <text fg={props.theme.success}>{`✓${counts().done} done`}</text>
+      <text fg={props.theme.success}>{`✓ ${counts().done} done`}</text>
       <text fg={props.theme.textMuted}> · </text>
-      <text fg={props.theme.error}>{`✕${counts().error} err`}</text>
+      <text fg={props.theme.error}>{`✕ ${counts().error} err`}</text>
       <text fg={props.theme.textMuted}> · </text>
-      <text fg={props.theme.warning}>{`Σ${totalExecuted()}`}</text>
+      <text fg={props.theme.text}>{`Σ ${totalExecuted()}`}</text>
     </box>
   );
 
@@ -1096,7 +1096,7 @@ function HomeBottomStatus(props: {
           <text fg={props.theme.textMuted}> · </text>
           <text fg={props.theme.error}>{`✕ ${counts().error}`}</text>
           <text fg={props.theme.textMuted}> · </text>
-          <text fg={props.theme.warning}>{`Σ${totalExecuted()}`}</text>
+          <text fg={props.theme.text}>{`Σ ${totalExecuted()}`}</text>
         </box>
       </box>
     </Show>

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -60,7 +60,7 @@ const SUBAGENTS_EXPANDED_KV_KEY = "subagents.sidebar.expanded";
 const SUBAGENTS_SECTION_ENABLED_KV_KEY = "subagents.sidebar.enabled";
 const SUBAGENTS_MAX_VISIBLE_ROWS = 5;
 const SUBAGENTS_RUNNING_ROW_HEIGHT = 3;
-const SUBAGENTS_TERMINAL_ROW_HEIGHT = 1;
+const SUBAGENTS_TERMINAL_ROW_HEIGHT = 2;
 const SUBAGENTS_ROW_GAP = 0;
 const SUBAGENTS_MAX_LIST_HEIGHT =
   SUBAGENTS_MAX_VISIBLE_ROWS * SUBAGENTS_RUNNING_ROW_HEIGHT +
@@ -750,31 +750,19 @@ function formatTerminalChildRowLine(input: {
   meta: string;
 } {
   const elapsed = formatDuration(elapsedMs(input.child, input.nowMs));
-  const width = Math.max(
-    MIN_ROW_WIDTH,
-    rowWidthBudget(input.sidebarWidth) - (input.reservedWidth ?? 0),
-  );
+  const width = Math.max(MIN_ROW_WIDTH, rowWidthBudget(input.sidebarWidth));
   const title = splitParentheticalTitle(childPrimaryText(input.child));
   const parenthetical = childParenthetical(input.child);
   const labelSource = parenthetical
     ? `${title.label} ${parenthetical}`
     : title.label;
-
-  for (const context of contextVariants(input.child)) {
-    const meta = context ? `${elapsed} · ${context}` : elapsed;
-    const metaWidth = meta.length + 3;
-    const labelBudget = width - metaWidth;
-    if (labelBudget >= MIN_LABEL_WIDTH || context.length === 0) {
-      return {
-        label: ellipsize(labelSource, Math.max(1, labelBudget)),
-        meta,
-      };
-    }
-  }
+  const context = contextVariants(input.child).find((variant) => variant.length > 0);
 
   return {
-    label: ellipsize(labelSource, Math.max(1, width - elapsed.length - 3)),
-    meta: elapsed,
+    label: ellipsize(labelSource, Math.max(1, width - (input.reservedWidth ?? 0))),
+    meta: context
+      ? `${elapsed} ${context}`
+      : elapsed,
   };
 }
 
@@ -989,16 +977,18 @@ function SidebarSubagents(props: {
         <Show
           when={status() === "running"}
           fallback={
-            <box flexDirection="row">
-              <text fg={statusColor(status(), props.theme)}>
-                {taskStatusMarker(status())}
-              </text>
-              <text
-                fg={muted() ? props.theme.textMuted : props.theme.text}
-              >{` ${terminalLine().label}`}</text>
+            <box flexDirection="column">
+              <box flexDirection="row">
+                <text fg={statusColor(status(), props.theme)}>
+                  {taskStatusMarker(status())}
+                </text>
+                <text
+                  fg={muted() ? props.theme.textMuted : props.theme.text}
+                >{` ${terminalLine().label}`}</text>
+              </box>
               <text
                 fg={emphasized() ? props.theme.text : props.theme.textMuted}
-              >{` · ${terminalLine().meta}`}</text>
+              >{`    ↳ ${CLOCK_ICON} ${terminalLine().meta}`}</text>
             </box>
           }
         >

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -137,6 +137,8 @@ function debugEvent(event: unknown): void {
 function cloneState(state: StatuslineState): StatuslineState {
   return {
     updatedAt: state.updatedAt,
+    totalExecuted: state.totalExecuted,
+    countedChildIDs: { ...state.countedChildIDs },
     children: Object.fromEntries(
       Object.entries(state.children).map(([id, child]) => [
         id,
@@ -783,6 +785,7 @@ function SidebarSubagents(props: {
     }
     return result;
   });
+  const totalExecuted = createMemo(() => props.state().totalExecuted ?? 0);
 
   const visibleChildren = createMemo(() => {
     const ownChildren = children();
@@ -951,6 +954,7 @@ function SidebarSubagents(props: {
       <text fg={props.theme.success}>{`✓ ${counts().done} done`}</text>
       <text fg={props.theme.textMuted}> · </text>
       <text fg={props.theme.error}>{`✕ ${counts().error} error`}</text>
+      <text fg={props.theme.textMuted}>{` · Σ ${totalExecuted()} total`}</text>
     </box>
   );
 
@@ -999,7 +1003,10 @@ function HomeBottomStatus(props: {
     }
     return result;
   });
-  const visible = createMemo(() => counts().running > 0 || counts().error > 0);
+  const totalExecuted = createMemo(() => props.state().totalExecuted ?? 0);
+  const visible = createMemo(
+    () => counts().running > 0 || counts().error > 0 || totalExecuted() > 0,
+  );
 
   return (
     <Show when={visible()}>
@@ -1010,6 +1017,7 @@ function HomeBottomStatus(props: {
           <text fg={props.theme.success}>{`✓ ${counts().done}`}</text>
           <text fg={props.theme.textMuted}> · </text>
           <text fg={props.theme.error}>{`✕ ${counts().error}`}</text>
+          <text fg={props.theme.textMuted}>{` · Σ ${totalExecuted()} total`}</text>
         </box>
       </box>
     </Show>

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -29,9 +29,7 @@ import type { Accessor } from "solid-js";
 import { applySubagentEvent, extractChildDetails } from "./events.js";
 import {
   byPriority,
-  collapseSubagentWorkItems,
   formatDuration,
-  isVisibleWorkItem,
   renderStatusLine,
   visibleSubagentWorkItems,
 } from "./render.js";
@@ -537,12 +535,6 @@ function navigateToSessionTarget(
   api.route.navigate("session", { sessionID: targetSessionID });
 }
 
-function collapseToolWrappers(
-  children: ChildSessionState[],
-): ChildSessionState[] {
-  return collapseSubagentWorkItems(children);
-}
-
 function toFinitePositiveInt(value: unknown): number | undefined {
   if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
   const rounded = Math.floor(value);
@@ -636,9 +628,9 @@ function resolveTokenTotal(child: ChildSessionState): number | undefined {
 
 function formatCompactTokenCount(total: number): string {
   const value = Math.max(0, total);
-  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M tok`;
-  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k tok`;
-  return `${Math.round(value)} tok`;
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M ctx`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k ctx`;
+  return `${Math.round(value)} ctx`;
 }
 
 function formatCompactPercent(percent: number): string {
@@ -755,24 +747,31 @@ function SidebarSubagents(props: {
   sidebarWidth?: () => number | undefined;
   theme: TuiThemeCurrent;
 }) {
+  const activeOnly = (items: ChildSessionState[]): ChildSessionState[] => {
+    if (!items.some((child) => child.status === "running")) return items;
+    return items.filter((child) => child.status !== "done");
+  };
+
   const children = createMemo(() =>
-    collapseToolWrappers(
-      Object.values(props.state().children).filter(
-        (child) => child.parentID === props.sessionID,
+    activeOnly(
+      visibleSubagentWorkItems(
+        Object.values(props.state().children).filter(
+          (child) => child.parentID === props.sessionID,
+        ),
+        props.nowMs(),
       ),
-    )
-      .filter((child) => isVisibleWorkItem(child, props.nowMs()))
-      .sort(byPriority),
+    ).sort(byPriority),
   );
 
   const otherChildren = createMemo(() =>
-    collapseToolWrappers(
-      Object.values(props.state().children).filter(
-        (child) => child.parentID !== props.sessionID,
+    activeOnly(
+      visibleSubagentWorkItems(
+        Object.values(props.state().children).filter(
+          (child) => child.parentID !== props.sessionID,
+        ),
+        props.nowMs(),
       ),
-    )
-      .filter((child) => isVisibleWorkItem(child, props.nowMs()))
-      .sort(byPriority),
+    ).sort(byPriority),
   );
 
   const counts = createMemo(() => {

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -58,12 +58,13 @@ const CLOCK_ICON = "";
 const TOKEN_ICON = "";
 const SUBAGENTS_EXPANDED_KV_KEY = "subagents.sidebar.expanded";
 const SUBAGENTS_SECTION_ENABLED_KV_KEY = "subagents.sidebar.enabled";
-const SUBAGENTS_VISIBLE_ROWS = 5;
-const SUBAGENTS_ROW_HEIGHT = 3;
+const SUBAGENTS_MAX_VISIBLE_ROWS = 5;
+const SUBAGENTS_RUNNING_ROW_HEIGHT = 3;
+const SUBAGENTS_TERMINAL_ROW_HEIGHT = 1;
 const SUBAGENTS_ROW_GAP = 0;
 const SUBAGENTS_MAX_LIST_HEIGHT =
-  SUBAGENTS_VISIBLE_ROWS * SUBAGENTS_ROW_HEIGHT +
-  (SUBAGENTS_VISIBLE_ROWS - 1) * SUBAGENTS_ROW_GAP;
+  SUBAGENTS_MAX_VISIBLE_ROWS * SUBAGENTS_RUNNING_ROW_HEIGHT +
+  (SUBAGENTS_MAX_VISIBLE_ROWS - 1) * SUBAGENTS_ROW_GAP;
 const INACTIVE_SUBAGENT_OPACITY = 0.65;
 
 interface SidebarScrollRegistration {
@@ -739,6 +740,50 @@ function formatChildRowLine(input: {
   };
 }
 
+function formatTerminalChildRowLine(input: {
+  child: ChildSessionState;
+  nowMs: number;
+  sidebarWidth?: number;
+  reservedWidth?: number;
+}): {
+  label: string;
+  meta: string;
+} {
+  const elapsed = formatDuration(elapsedMs(input.child, input.nowMs));
+  const width = Math.max(
+    MIN_ROW_WIDTH,
+    rowWidthBudget(input.sidebarWidth) - (input.reservedWidth ?? 0),
+  );
+  const title = splitParentheticalTitle(childPrimaryText(input.child));
+  const parenthetical = childParenthetical(input.child);
+  const labelSource = parenthetical
+    ? `${title.label} ${parenthetical}`
+    : title.label;
+
+  for (const context of contextVariants(input.child)) {
+    const meta = context ? `${elapsed} · ${context}` : elapsed;
+    const metaWidth = meta.length + 3;
+    const labelBudget = width - metaWidth;
+    if (labelBudget >= MIN_LABEL_WIDTH || context.length === 0) {
+      return {
+        label: ellipsize(labelSource, Math.max(1, labelBudget)),
+        meta,
+      };
+    }
+  }
+
+  return {
+    label: ellipsize(labelSource, Math.max(1, width - elapsed.length - 3)),
+    meta: elapsed,
+  };
+}
+
+function subagentRowHeight(child: ChildSessionState): number {
+  return child.status === "running"
+    ? SUBAGENTS_RUNNING_ROW_HEIGHT
+    : SUBAGENTS_TERMINAL_ROW_HEIGHT;
+}
+
 function SidebarSubagents(props: {
   api: TuiPluginApi;
   sessionID: string;
@@ -819,6 +864,17 @@ function SidebarSubagents(props: {
       .join("|"),
   );
 
+  const listHeight = createMemo(() => {
+    const contentHeight =
+      visibleChildren().reduce(
+        (height, child) => height + subagentRowHeight(child),
+        showingOtherSessions() ? 1 : 0,
+      ) +
+      Math.max(0, visibleChildren().length - 1) * SUBAGENTS_ROW_GAP;
+
+    return Math.max(1, Math.min(SUBAGENTS_MAX_LIST_HEIGHT, contentHeight));
+  });
+
   let scrollbox: ScrollBoxRenderable | undefined;
   let restoreScrollTimeout: ReturnType<typeof setTimeout> | undefined;
   const scrollRegistration: SidebarScrollRegistration = {
@@ -884,7 +940,23 @@ function SidebarSubagents(props: {
         reservedWidth: markerWidth,
       });
     });
+    const terminalLine = createMemo(() => {
+      const currentChild = child();
+      if (!currentChild) return { label: "", meta: "00:00" };
+      return formatTerminalChildRowLine({
+        child: currentChild,
+        nowMs: props.nowMs(),
+        sidebarWidth: props.sidebarWidth?.(),
+        reservedWidth: markerWidth,
+      });
+    });
     const hasSecondaryLine = createMemo(() => Boolean(line().secondaryLine));
+    const rowHeight = createMemo(() => {
+      if (status() !== "running") return SUBAGENTS_TERMINAL_ROW_HEIGHT;
+      return hasSecondaryLine()
+        ? SUBAGENTS_RUNNING_ROW_HEIGHT
+        : SUBAGENTS_RUNNING_ROW_HEIGHT - 1;
+    });
     const activate = () =>
       navigateToSessionTarget(props.api, targetSessionID());
     const handleKeyDown = (event: { name: string }): void => {
@@ -898,11 +970,7 @@ function SidebarSubagents(props: {
     return (
       <box
         flexDirection="column"
-        height={
-          hasSecondaryLine()
-            ? SUBAGENTS_ROW_HEIGHT
-            : SUBAGENTS_ROW_HEIGHT - 1
-        }
+        height={rowHeight()}
         opacity={rowOpacity()}
         onMouseOver={clickable() ? () => setHovered(true) : undefined}
         onMouseOut={
@@ -918,43 +986,62 @@ function SidebarSubagents(props: {
         focusable={clickable()}
         focused={clickable() && focused()}
       >
-        <box flexDirection="row">
-          <text fg={statusColor(status(), props.theme)}>
-            {taskStatusMarker(status())}
-          </text>
-          <text
-            fg={muted() ? props.theme.textMuted : props.theme.text}
-          >{` ${line().labelLines[0] ?? ""}`}</text>
-        </box>
-        <Show when={line().secondaryLine}>
-          {(secondaryLine: Accessor<string>) => (
-            <text
-              fg={muted() ? props.theme.textMuted : props.theme.text}
-            >{`    ${secondaryLine()}`}</text>
-          )}
+        <Show
+          when={status() === "running"}
+          fallback={
+            <box flexDirection="row">
+              <text fg={statusColor(status(), props.theme)}>
+                {taskStatusMarker(status())}
+              </text>
+              <text
+                fg={muted() ? props.theme.textMuted : props.theme.text}
+              >{` ${terminalLine().label}`}</text>
+              <text
+                fg={emphasized() ? props.theme.text : props.theme.textMuted}
+              >{` · ${terminalLine().meta}`}</text>
+            </box>
+          }
+        >
+          <box flexDirection="column">
+            <box flexDirection="row">
+              <text fg={statusColor(status(), props.theme)}>
+                {taskStatusMarker(status())}
+              </text>
+              <text
+                fg={muted() ? props.theme.textMuted : props.theme.text}
+              >{` ${line().labelLines[0] ?? ""}`}</text>
+            </box>
+            <Show when={line().secondaryLine}>
+              {(secondaryLine: Accessor<string>) => (
+                <text
+                  fg={muted() ? props.theme.textMuted : props.theme.text}
+                >{`    ${secondaryLine()}`}</text>
+              )}
+            </Show>
+            <box flexDirection="row" paddingLeft={4}>
+              <text
+                fg={emphasized() ? props.theme.text : props.theme.textMuted}
+              >{`↳ ${CLOCK_ICON} ${line().elapsed}`}</text>
+              <Show when={line().meta.length > 0}>
+                <text
+                  fg={emphasized() ? props.theme.text : props.theme.textMuted}
+                >{` ${TOKEN_ICON} ${line().meta}`}</text>
+              </Show>
+            </box>
+          </box>
         </Show>
-        <box flexDirection="row" paddingLeft={4}>
-          <text
-            fg={emphasized() ? props.theme.text : props.theme.textMuted}
-          >{`↳ ${CLOCK_ICON} ${line().elapsed}`}</text>
-          <Show when={line().meta.length > 0}>
-            <text
-              fg={emphasized() ? props.theme.text : props.theme.textMuted}
-            >{` ${TOKEN_ICON} ${line().meta}`}</text>
-          </Show>
-        </box>
       </box>
     );
   };
 
   const AggregateBar = () => (
     <box flexDirection="row" paddingRight={1}>
-      <text fg={props.theme.warning}>{`● ${counts().running} running`}</text>
+      <text fg={props.theme.warning}>{`●${counts().running} run`}</text>
       <text fg={props.theme.textMuted}> · </text>
-      <text fg={props.theme.success}>{`✓ ${counts().done} done`}</text>
+      <text fg={props.theme.success}>{`✓${counts().done} done`}</text>
       <text fg={props.theme.textMuted}> · </text>
-      <text fg={props.theme.error}>{`✕ ${counts().error} error`}</text>
-      <text fg={props.theme.textMuted}>{` · Σ ${totalExecuted()} total`}</text>
+      <text fg={props.theme.error}>{`✕${counts().error} err`}</text>
+      <text fg={props.theme.textMuted}>{` · Σ${totalExecuted()}`}</text>
     </box>
   );
 
@@ -972,7 +1059,7 @@ function SidebarSubagents(props: {
           ref={(element) => {
             scrollbox = element;
           }}
-          height={SUBAGENTS_MAX_LIST_HEIGHT}
+          height={listHeight()}
           scrollY
           viewportCulling={false}
         >


### PR DESCRIPTION
## Summary

Follow-up to #29.

- Reworks subagent work-item collapse to use indexed parent/session maps instead of repeated global scans.
- Adds conservative pruning for old terminal children so persisted state cannot grow without bound.
- Keeps the sidebar focused on active work by hiding completed rows while any row in that list is still running.
- Renames compact context usage from `tok` to `ctx` to better match what the metric represents.

## Why

After testing #29 locally with long-running and completed delegations, the UX was cleaner but there were still two issues:

1. Large histories could keep increasing the cost of sidebar/statusline rendering.
2. Completed rows from previous work could still clutter the sidebar while a new task was active.

This PR keeps the behavior from #29, but makes the render path cheaper and bounds old terminal state.

## Validation

- [x] `corepack pnpm run typecheck`
- [x] `corepack pnpm run build`
- [x] Manually tested the local TUI plugin through an absolute `tui.json` path with planned tasks and delegated subagents

## Notes

Known limitation: delegate-backed subagents may remain visually `running` until OpenCode emits/processes the parent-side completion event. Detecting child-session completion independently would require separate polling/hydration work and is intentionally left out of this focused PR.

## Checklist

- [x] I used a Conventional Commit title (e.g. `fix: ...`, `feat: ...`, `docs: ...`)
- [x] I linked related issue(s), or explained why none are needed
- [x] I did not include secrets, credentials, or private data
- [x] I called out any security-sensitive behavior changes
- [ ] I updated docs when behavior or usage changed

Security-sensitive behavior changes: none.
Docs: not updated; behavior is visible in the sidebar/statusline and this is a focused follow-up to #29.