### PR TITLE
test: add plugin testing strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist/
 *.log
 *.tmp
 .DS_Store
+.atl/
+coverage/

--- a/README.md
+++ b/README.md
@@ -111,8 +111,25 @@ Useful commands:
 ```sh
 pnpm build
 pnpm typecheck
+pnpm test
+pnpm test:watch
+pnpm test:coverage
 pnpm pack --dry-run
 ```
+
+## Testing
+
+Automated tests use Vitest with `@vitest/coverage-v8`:
+
+```sh
+pnpm test
+pnpm test:watch
+pnpm test:coverage
+pnpm typecheck
+```
+
+For the testing strategy, file map, examples, and current TUI/e2e boundaries, see
+[`docs/testing.md`](docs/testing.md).
 
 ---
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,175 @@
+# Testing
+
+This project uses **Vitest** for automated tests and **@vitest/coverage-v8** for coverage reports. The goal is to keep the fast, deterministic behavior covered in tests while avoiding brittle host-driven TUI automation too early.
+
+## Strategy overview
+
+The suite has two layers:
+
+- **Unit tests** cover pure logic in `src/events.ts`, `src/state.ts`, and `src/render.ts`. These tests should be fast, table-friendly, and focused on behavior: parsed session data, state transitions, counters, formatting, and safe handling of malformed input.
+- **Runtime integration tests** cover `src/index.ts`, where the plugin touches the filesystem and OpenCode-style event handling. These tests instantiate the plugin against isolated temporary directories and assert persisted state/output.
+
+Deep TUI and full OpenCode host end-to-end automation are intentionally deferred. The current priority is a reliable core runtime layer before adding expensive or brittle UI automation.
+
+## Test file map
+
+| File                              | What it validates                                                                                                                                                  |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `src/events.test.ts`              | Event parsing, session ID extraction, event-to-state updates, details/token normalization, and malformed event safety.                                             |
+| `src/state.test.ts`               | State invariants, counters, transitions, pruning, persistence helpers, environment path resolution, and detail merging.                                            |
+| `src/render.test.ts`              | Statusline rendering, visibility rules, collapse behavior, duration/token formatting, and color/no-color output semantics.                                         |
+| `test/index.integration.test.ts`  | Runtime plugin initialization, event handling, `state.json` persistence, `status.txt` writes, preserve-state behavior, malformed events, and write-failure safety. |
+| `test/helpers/runtime-harness.ts` | Reusable helpers for temp dirs, env overrides, fixtures, filesystem assertions, and fake-time setup.                                                               |
+| `test/setup.ts`                   | Global cleanup after each test: timers, mocks, selected env vars, and registered temp directories.                                                                 |
+| `test/fixtures/events/*.json`     | Canonical valid and malformed event payloads used by tests.                                                                                                        |
+
+## Arrange / Act / Assert
+
+Use the **Arrange / Act / Assert** pattern to keep tests readable:
+
+```ts
+it("persists a supported event", async () => {
+  // Arrange
+  const harness = await createRuntimeHarness();
+  const plugin = await SubagentStatusline(
+    {} as Parameters<typeof SubagentStatusline>[0],
+  );
+  const event = await readJsonFixture("session-created");
+
+  // Act
+  await plugin.event?.({ event } as never);
+
+  // Assert
+  const state = await readRuntimeState(harness.statePath);
+  expect(state.children.ses_child_1.status).toBe("running");
+});
+```
+
+Keep assertions semantic. Prefer checking meaningful counters, titles, statuses, file contents, or rendered text over snapshots of large objects.
+
+## Running tests
+
+Install dependencies first:
+
+```sh
+pnpm install
+```
+
+Run the full suite once:
+
+```sh
+pnpm test
+```
+
+Run tests in watch mode while developing:
+
+```sh
+pnpm test:watch
+```
+
+Generate coverage:
+
+```sh
+pnpm test:coverage
+```
+
+Run TypeScript checks:
+
+```sh
+pnpm typecheck
+```
+
+## Adding a unit test
+
+1. Pick the module behavior you want to protect.
+2. Add or extend the co-located test file: `src/events.test.ts`, `src/state.test.ts`, or `src/render.test.ts`.
+3. Arrange minimal inputs. Reuse existing helpers or fixtures only when they make the test clearer.
+4. Act by calling the public function under test.
+5. Assert behavior, not implementation details.
+
+Example shape:
+
+```ts
+it("renders an empty summary", () => {
+  const state = createEmptyState();
+
+  const output = renderStatusline(state);
+
+  expect(output).toContain("0 running");
+  expect(output).toContain("0 done");
+});
+```
+
+If a case depends on time, use `useFrozenTime(...)` from `test/helpers/runtime-harness.ts` or Vitest fake timers directly, and let `test/setup.ts` restore real timers after the test.
+
+## Adding a runtime integration test
+
+Runtime integration tests should live in `test/index.integration.test.ts` or another `test/*.integration.test.ts` file.
+
+Use the harness so each test gets isolated filesystem state:
+
+```ts
+it("writes runtime output after an event", async () => {
+  const harness = await createRuntimeHarness();
+  const plugin = await SubagentStatusline(
+    {} as Parameters<typeof SubagentStatusline>[0],
+  );
+  const event = await readJsonFixture("session-created");
+
+  await plugin.event?.({ event } as never);
+
+  expect(await readStatusText(harness.textPath)).toContain(
+    "Review auth changes",
+  );
+});
+```
+
+Useful helpers:
+
+- `createRuntimeHarness({ preserveState?: boolean })` creates a temp directory and sets the plugin env vars for that test.
+- `readJsonFixture(name)` loads `test/fixtures/events/<name>.json`.
+- `readRuntimeState(path)` reads persisted `state.json`.
+- `readStatusText(path)` reads persisted status text.
+- `pathExists(path)` checks filesystem output without throwing.
+- `useFrozenTime(isoTimestamp)` enables fake timers and pins the current time.
+
+Add new event fixtures under `test/fixtures/events/` when the same payload is useful across tests. Keep fixtures small and representative.
+
+## What not to test yet
+
+Do not add deep TUI/e2e automation for `src/tui.tsx` yet. Full OpenCode host automation, visual snapshots, and broad OpenTUI rendering assertions are deferred until the runtime layer and future TUI seams are stable.
+
+For now, prefer:
+
+- unit tests for pure formatting and state behavior;
+- integration tests for plugin runtime persistence and event handling;
+- manual smoke testing in OpenCode when changing the actual TUI surface.
+
+## Troubleshooting and gotchas
+
+### Fake timers
+
+If a test uses fake timers, make sure it is explicit in the Arrange step. `test/setup.ts` calls `vi.useRealTimers()` after each test, but a test should still avoid leaking timer state through shared module-level values.
+
+### Temporary directories
+
+Use `createRuntimeHarness()` instead of hard-coded paths. It registers temp directories for cleanup and points `OPENCODE_SUBAGENT_STATUSLINE_STATE` at an isolated `state.json`.
+
+### Environment variables
+
+The setup file restores the plugin-related env vars after each test. If you add a new env var that tests mutate, add it to `envKeys` in `test/setup.ts`.
+
+### Avoid brittle snapshots
+
+Snapshots can hide intent and break on harmless formatting changes. Prefer focused assertions like:
+
+```ts
+expect(output).toContain("1 running");
+expect(output).toContain("Review auth changes");
+```
+
+Use snapshots only when the whole rendered shape is the behavior being protected and the output is intentionally stable.
+
+### Write failures
+
+Integration tests can simulate filesystem write failures by making the expected state path a directory. Keep these tests small and assert that plugin event handling does not throw.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "build": "tsup",
     "prepack": "pnpm run build",
     "release": "semantic-release",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "dev": "tsup --watch"
   },
@@ -50,10 +53,12 @@
     "@semantic-release/npm": "^12.0.2",
     "@semantic-release/release-notes-generator": "^14.1.0",
     "@types/node": "^22.15.21",
+    "@vitest/coverage-v8": "^4.1.5",
     "esbuild-plugin-solid": "^0.6.0",
     "semantic-release": "^24.2.9",
     "tsup": "^8.5.1",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^4.1.5"
   },
   "release": {
     "branches": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@types/node':
         specifier: ^22.15.21
         version: 22.19.17
+      '@vitest/coverage-v8':
+        specifier: ^4.1.5
+        version: 4.1.5(vitest@4.1.5)
       esbuild-plugin-solid:
         specifier: ^0.6.0
         version: 0.6.0(esbuild@0.27.7)(solid-js@1.9.12)
@@ -44,10 +47,13 @@ importers:
         version: 24.2.9(typescript@5.9.3)
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.12)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(yaml@2.8.3))
 
 packages:
 
@@ -188,12 +194,25 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
+
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
 
   '@dimforge/rapier2d-simd-compat@0.17.3':
     resolution: {integrity: sha512-bijvwWz6NHsNj5e5i1vtd3dU2pDhthSaTUZSh14DUGGKJfw8eMnlWZsxwHBxB/a3AXVNDjL9abuHw1k9FGR+jg==}
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -506,6 +525,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@octokit/auth-token@6.0.0':
     resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
     engines: {node: '>= 20'}
@@ -614,6 +639,9 @@ packages:
     peerDependencies:
       solid-js: 1.9.11
 
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
     engines: {node: '>=12.22.0'}
@@ -625,6 +653,104 @@ packages:
   '@pnpm/npm-conf@3.0.2':
     resolution: {integrity: sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==}
     engines: {node: '>=12'}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.17':
+    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
   '@rollup/rollup-android-arm-eabi@4.60.2':
     resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
@@ -813,6 +939,15 @@ packages:
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -824,6 +959,44 @@ packages:
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
+  '@vitest/coverage-v8@4.1.5':
+    resolution: {integrity: sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==}
+    peerDependencies:
+      '@vitest/browser': 4.1.5
+      vitest: 4.1.5
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
   '@webgpu/types@0.1.69':
     resolution: {integrity: sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==}
@@ -879,6 +1052,13 @@ packages:
 
   array-ify@1.0.0:
     resolution: {integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.0:
+    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
   await-to-js@3.0.0:
     resolution: {integrity: sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g==}
@@ -980,6 +1160,10 @@ packages:
 
   caniuse-lite@1.0.30001790:
     resolution: {integrity: sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -1170,6 +1354,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
   esbuild-plugin-solid@0.6.0:
     resolution: {integrity: sha512-V1FvDALwLDX6K0XNYM9CMRAnMzA0+Ecu55qBUT9q/eAJh1KIDsTMFoOzMSgyHqbOfvrVfO3Mws3z7TW2GVnIZA==}
     peerDependencies:
@@ -1193,6 +1380,9 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
@@ -1211,6 +1401,10 @@ packages:
 
   exif-parser@0.1.12:
     resolution: {integrity: sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fast-check@4.7.0:
     resolution: {integrity: sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==}
@@ -1367,6 +1561,9 @@ packages:
   html-entities@2.3.3:
     resolution: {integrity: sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==}
 
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
@@ -1467,6 +1664,18 @@ packages:
     resolution: {integrity: sha512-3YZcUUR2Wt1WsapF+S/WiA2WmlW0cWAoPccMqne7AxEBhCdFeTPjfv/Axb8V2gyCgY3nRw+ksZ3xSUX+R47iAg==}
     engines: {node: ^18.17 || >=20.6.1}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   java-properties@1.0.2:
     resolution: {integrity: sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==}
     engines: {node: '>= 0.6.0'}
@@ -1481,6 +1690,9 @@ packages:
 
   jpeg-js@0.4.4:
     resolution: {integrity: sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -1513,6 +1725,80 @@ packages:
 
   kubernetes-types@1.30.0:
     resolution: {integrity: sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==}
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -1564,9 +1850,16 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  magicast@0.5.2:
+    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+
   make-asynchronous@1.1.0:
     resolution: {integrity: sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==}
     engines: {node: '>=18'}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   marked-terminal@7.3.0:
     resolution: {integrity: sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==}
@@ -1642,6 +1935,11 @@ packages:
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
@@ -1753,6 +2051,9 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   omggif@1.0.10:
     resolution: {integrity: sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==}
@@ -1953,6 +2254,10 @@ packages:
       yaml:
         optional: true
 
+  postcss@8.5.12:
+    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
+    engines: {node: ^10 || ^12 || >=14}
+
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
@@ -2021,6 +2326,11 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  rolldown@1.0.0-rc.17:
+    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rollup@4.60.2:
     resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -2080,6 +2390,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -2098,6 +2411,10 @@ packages:
 
   solid-js@1.9.12:
     resolution: {integrity: sha512-QzKaSJq2/iDrWR1As6MHZQ8fQkdOBf8GReYb7L5iKwMGceg7HxDcaOHk0at66tNgn9U2U7dXo8ZZpLIAmGMzgw==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
 
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
@@ -2125,9 +2442,15 @@ packages:
   split2@1.0.0:
     resolution: {integrity: sha512-NKywug4u4pX/AZBB1FCPzZ6/7O+Xhz1qMVbzTvvKvikjO99oPN87SkK08mEY9P63/5lWjK+wgOOgApnTg5r6qg==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stage-js@1.0.2:
     resolution: {integrity: sha512-EWTRBYlg7Qv9wGUao99/PfRe3KaiQqWmgSvTOXvaWnu1Jk/q/vV8yJVu6bi/3EqDZeMVnCPAjheba6OFc5k1GQ==}
     engines: {node: '>=24.0'}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stream-combiner2@1.1.1:
     resolution: {integrity: sha512-3PnJbYgS56AeWgtKF5jtJRT6uFJe56Z0Hc5Ngg/6sI6rIt8iiMBTa9cvdyFfpMQjaVHr8dusbNeFGIIonxOvKw==}
@@ -2216,15 +2539,26 @@ packages:
     resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
     engines: {node: '>=12'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinycolor2@1.6.0:
     resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
+  tinyexec@1.1.2:
+    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -2248,6 +2582,9 @@ packages:
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsup@8.5.1:
     resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
@@ -2342,6 +2679,90 @@ packages:
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
+  vite@8.0.10:
+    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-tree-sitter@0.25.10:
     resolution: {integrity: sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA==}
     peerDependencies:
@@ -2356,6 +2777,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wordwrap@1.0.0:
@@ -2618,10 +3044,28 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@bcoe/v8-coverage@1.0.2': {}
+
   '@colors/colors@1.5.0':
     optional: true
 
   '@dimforge/rapier2d-simd-compat@0.17.3':
+    optional: true
+
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
     optional: true
 
   '@esbuild/aix-ppc64@0.27.7':
@@ -2923,6 +3367,13 @@ snapshots:
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@octokit/auth-token@6.0.0': {}
 
   '@octokit/core@7.0.6':
@@ -3059,6 +3510,8 @@ snapshots:
       - typescript
       - web-tree-sitter
 
+  '@oxc-project/types@0.127.0': {}
+
   '@pnpm/config.env-replace@1.1.0': {}
 
   '@pnpm/network.ca-file@1.0.2':
@@ -3070,6 +3523,57 @@ snapshots:
       '@pnpm/config.env-replace': 1.1.0
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.17': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.2':
     optional: true
@@ -3229,6 +3733,18 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/node@16.9.1': {}
@@ -3238,6 +3754,61 @@ snapshots:
       undici-types: 6.21.0
 
   '@types/normalize-package-data@2.4.4': {}
+
+  '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.5
+      ast-v8-to-istanbul: 1.0.0
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(yaml@2.8.3))
+
+  '@vitest/expect@4.1.5':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(yaml@2.8.3)
+
+  '@vitest/pretty-format@4.1.5':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.5':
+    dependencies:
+      '@vitest/utils': 4.1.5
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.5': {}
+
+  '@vitest/utils@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@webgpu/types@0.1.69':
     optional: true
@@ -3280,6 +3851,14 @@ snapshots:
   argv-formatter@1.0.0: {}
 
   array-ify@1.0.0: {}
+
+  assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   await-to-js@3.0.0: {}
 
@@ -3376,6 +3955,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001790: {}
+
+  chai@6.2.2: {}
 
   chalk@2.4.2:
     dependencies:
@@ -3507,8 +4088,7 @@ snapshots:
 
   deep-extend@0.6.0: {}
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   diff@8.0.2: {}
 
@@ -3562,6 +4142,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@2.1.0: {}
+
   esbuild-plugin-solid@0.6.0(esbuild@0.27.7)(solid-js@1.9.12):
     dependencies:
       '@babel/core': 7.28.0
@@ -3607,6 +4189,10 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   event-target-shim@5.0.1: {}
 
   events@3.3.0: {}
@@ -3639,6 +4225,8 @@ snapshots:
       yoctocolors: 2.1.2
 
   exif-parser@0.1.12: {}
+
+  expect-type@1.3.0: {}
 
   fast-check@4.7.0:
     dependencies:
@@ -3786,6 +4374,8 @@ snapshots:
 
   html-entities@2.3.3: {}
 
+  html-escaper@2.0.2: {}
+
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
@@ -3871,6 +4461,19 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.uniqby: 4.7.0
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   java-properties@1.0.2: {}
 
   jimp@1.6.0:
@@ -3907,6 +4510,8 @@ snapshots:
 
   jpeg-js@0.4.4: {}
 
+  js-tokens@10.0.0: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
@@ -3930,6 +4535,55 @@ snapshots:
       graceful-fs: 4.2.11
 
   kubernetes-types@1.30.0: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   lilconfig@3.1.3: {}
 
@@ -3976,11 +4630,21 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magicast@0.5.2:
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
   make-asynchronous@1.1.0:
     dependencies:
       p-event: 6.0.1
       type-fest: 4.41.0
       web-worker: 1.5.0
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   marked-terminal@7.3.0(marked@15.0.12):
     dependencies:
@@ -4055,6 +4719,8 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
+  nanoid@3.3.11: {}
+
   neo-async@2.6.2: {}
 
   nerf-dart@1.0.0: {}
@@ -4093,6 +4759,8 @@ snapshots:
   npm@10.9.8: {}
 
   object-assign@4.1.1: {}
+
+  obug@2.1.1: {}
 
   omggif@1.0.10: {}
 
@@ -4242,11 +4910,18 @@ snapshots:
 
   pngjs@7.0.0: {}
 
-  postcss-load-config@6.0.1(yaml@2.8.3):
+  postcss-load-config@6.0.1(postcss@8.5.12)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
+      postcss: 8.5.12
       yaml: 2.8.3
+
+  postcss@8.5.12:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   pretty-ms@9.3.0:
     dependencies:
@@ -4323,6 +4998,27 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  rolldown@1.0.0-rc.17:
+    dependencies:
+      '@oxc-project/types': 0.127.0
+      '@rolldown/pluginutils': 1.0.0-rc.17
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
   rollup@4.60.2:
     dependencies:
@@ -4420,6 +5116,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   signale@1.4.0:
@@ -4439,6 +5137,8 @@ snapshots:
       csstype: 3.2.3
       seroval: 1.5.2
       seroval-plugins: 1.5.2(seroval@1.5.2)
+
+  source-map-js@1.2.1: {}
 
   source-map@0.6.1: {}
 
@@ -4464,8 +5164,12 @@ snapshots:
     dependencies:
       through2: 2.0.5
 
+  stackback@0.0.2: {}
+
   stage-js@1.0.2:
     optional: true
+
+  std-env@4.1.0: {}
 
   stream-combiner2@1.1.1:
     dependencies:
@@ -4563,14 +5267,20 @@ snapshots:
     dependencies:
       convert-hrtime: 5.0.0
 
+  tinybench@2.9.0: {}
+
   tinycolor2@1.6.0: {}
 
   tinyexec@0.3.2: {}
+
+  tinyexec@1.1.2: {}
 
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -4589,7 +5299,10 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tsup@8.5.1(typescript@5.9.3)(yaml@2.8.3):
+  tslib@2.8.1:
+    optional: true
+
+  tsup@8.5.1(postcss@8.5.12)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -4600,7 +5313,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(yaml@2.8.3)
+      postcss-load-config: 6.0.1(postcss@8.5.12)(yaml@2.8.3)
       resolve-from: 5.0.0
       rollup: 4.60.2
       source-map: 0.7.6
@@ -4609,6 +5322,7 @@ snapshots:
       tinyglobby: 0.2.16
       tree-kill: 1.2.2
     optionalDependencies:
+      postcss: 8.5.12
       typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
@@ -4666,6 +5380,47 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
+  vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.12
+      rolldown: 1.0.0-rc.17
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 22.19.17
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      yaml: 2.8.3
+
+  vitest@4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+      '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
+    transitivePeerDependencies:
+      - msw
+
   web-tree-sitter@0.25.10: {}
 
   web-worker@1.5.0: {}
@@ -4673,6 +5428,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wordwrap@1.0.0: {}
 

--- a/src/events.test.ts
+++ b/src/events.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  applySubagentEvent,
+  extractChildDetails,
+  extractSessionID,
+  type EventLike,
+} from "./events.js";
+import { createEmptyState } from "./state.js";
+import { readJsonFixture } from "../test/helpers/runtime-harness.js";
+
+describe("events", () => {
+  it("extracts session identifiers from supported event locations", () => {
+    expect(extractSessionID({ properties: { sessionID: "ses_props" } })).toBe(
+      "ses_props",
+    );
+    expect(extractSessionID({ sessionId: "ses_top" })).toBe("ses_top");
+    expect(extractSessionID({ properties: { info: { id: "ses_info" } } })).toBe(
+      "ses_info",
+    );
+  });
+
+  it("applies session-created events as running children", async () => {
+    const event = await readJsonFixture("session-created");
+    const state = createEmptyState();
+
+    expect(applySubagentEvent(state, event)).toBe(true);
+
+    expect(state.children.ses_child_1).toMatchObject({
+      id: "ses_child_1",
+      title: "Review auth changes",
+      agentName: "reviewer",
+      parentID: "ses_parent_1",
+      source: "session",
+      targetSessionID: "ses_child_1",
+      status: "running",
+      color: "yellow",
+    });
+    expect(state.totalExecuted).toBe(1);
+    expect(state.countedChildIDs.ses_child_1).toBe(true);
+  });
+
+  it("extracts useful tool details while replacing technical delegation titles", async () => {
+    const event = await readJsonFixture<EventLike>("tool-updated");
+
+    expect(extractChildDetails(event)).toMatchObject({
+      title: "Investigate flaky tests",
+      summary: "Investigate why tests are flaky and report findings. Include commands run.",
+      agentName: "tester",
+      tokens: {
+        input: 1000,
+        output: 250,
+        contextPercent: 42,
+      },
+    });
+  });
+
+  it("is deterministic and safe for malformed input", async () => {
+    const malformed = await readJsonFixture("malformed");
+    const state = createEmptyState();
+
+    expect(applySubagentEvent(state, malformed)).toBe(false);
+    expect(applySubagentEvent(state, null)).toBe(false);
+    expect(state.children).toEqual({});
+  });
+});

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import {
+  collapseSubagentWorkItems,
+  formatContext,
+  formatContextCompact,
+  formatContextDetails,
+  formatDuration,
+  renderStatusLine,
+  visibleSubagentWorkItems,
+} from "./render.js";
+import type { ChildSessionState, StatuslineState } from "./state.js";
+
+function child(overrides: Partial<ChildSessionState> = {}): ChildSessionState {
+  return {
+    id: "ses_child",
+    title: "Review auth changes",
+    parentID: "ses_parent",
+    messageID: "msg_1",
+    source: "session",
+    targetSessionID: "ses_child",
+    status: "running",
+    color: "yellow",
+    startedAt: "2026-04-30T10:00:00.000Z",
+    updatedAt: "2026-04-30T10:01:00.000Z",
+    elapsedMs: 61000,
+    ...overrides,
+  };
+}
+
+describe("render", () => {
+  it("formats durations and context details semantically", () => {
+    const withTokens = child({ tokens: { input: 1200, output: 300, contextPercent: 12.34 } });
+
+    expect(formatDuration(61000)).toBe("01:01");
+    expect(formatDuration(3_661_000)).toBe("01:01:01");
+    expect(formatContextDetails(withTokens)).toBe("1,500 tokens · 12.3% used");
+    expect(formatContext(withTokens)).toBe("ctx 1,500 tokens · 12.3% used");
+    expect(formatContextCompact(withTokens)).toBe("1.5k ctx 12%");
+  });
+
+  it("collapses synthetic work items with matching session children", () => {
+    const synthetic = child({
+      id: "tool:part_1",
+      title: "Investigate flaky tests",
+      source: "tool",
+      targetSessionID: "ses_child",
+      agentName: "tester",
+    });
+    const session = child({
+      id: "ses_child",
+      title: "Investigate flaky tests",
+      source: "session",
+      status: "done",
+      color: "green",
+      endedAt: "2026-04-30T10:04:00.000Z",
+      elapsedMs: 240000,
+    });
+
+    expect(collapseSubagentWorkItems([synthetic, session])).toEqual([
+      expect.objectContaining({
+        id: "tool:part_1",
+        status: "done",
+        color: "green",
+        targetSessionID: "ses_child",
+        elapsedMs: 240000,
+      }),
+    ]);
+  });
+
+  it("keeps recent done items visible and hides stale done items", () => {
+    const now = Date.parse("2026-04-30T10:20:00.000Z");
+    const visibleDone = child({
+      id: "done_recent",
+      status: "done",
+      color: "green",
+      endedAt: "2026-04-30T10:15:00.000Z",
+    });
+    const hiddenDone = child({
+      id: "done_old",
+      status: "done",
+      color: "green",
+      endedAt: "2026-04-30T10:00:00.000Z",
+    });
+
+    expect(visibleSubagentWorkItems([visibleDone, hiddenDone], now).map((item) => item.id)).toEqual([
+      "done_recent",
+    ]);
+  });
+
+  it("renders aggregate and detail statusline output without color when disabled", () => {
+    process.env.NO_COLOR = "1";
+    const state: StatuslineState = {
+      children: {
+        running: child({ id: "running", title: "Run tests", status: "running", color: "yellow" }),
+        error: child({ id: "error", title: "Fix bug", status: "error", color: "red" }),
+      },
+      countedChildIDs: { running: true, error: true },
+      totalExecuted: 2,
+      updatedAt: "2026-04-30T10:00:00.000Z",
+    };
+
+    expect(renderStatusLine(state)).toContain("↳ 1 running · 0 done · 1 error · Σ 2 total");
+    expect(renderStatusLine(state)).toContain("Run tests 01:01");
+    expect(renderStatusLine(state)).not.toContain("\u001B[");
+  });
+});

--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -1,0 +1,147 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  createEmptyState,
+  getCounts,
+  loadState,
+  markChildStatus,
+  pruneTerminalChildren,
+  refreshDerivedFields,
+  resolveStatePath,
+  resolveTextPath,
+  saveState,
+  shouldPreserveStateOnStartup,
+  upsertChildDetails,
+  upsertRunningChild,
+  type ChildSessionState,
+} from "./state.js";
+import {
+  createRuntimeHarness,
+  readRuntimeState,
+  useFrozenTime,
+} from "../test/helpers/runtime-harness.js";
+
+function child(overrides: Partial<ChildSessionState> = {}): ChildSessionState {
+  return {
+    id: "ses_child",
+    title: "Child work",
+    parentID: "ses_parent",
+    source: "session",
+    targetSessionID: "ses_child",
+    status: "running",
+    color: "yellow",
+    startedAt: "2026-04-30T10:00:00.000Z",
+    updatedAt: "2026-04-30T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("state", () => {
+  it("upserts running children, counts work once, and marks terminal statuses", () => {
+    useFrozenTime("2026-04-30T10:05:00.000Z");
+    const state = createEmptyState();
+
+    expect(
+      upsertRunningChild(state, {
+        id: "tool:part_1",
+        title: "Run tests",
+        parentID: "ses_parent",
+        source: "tool",
+        startedAt: "2026-04-30T10:00:00.000Z",
+      }),
+    ).toBe(true);
+    expect(state.totalExecuted).toBe(1);
+
+    expect(
+      upsertRunningChild(state, {
+        id: "tool:part_1",
+        title: "Run tests",
+        parentID: "ses_parent",
+        source: "tool",
+      }),
+    ).toBe(false);
+    expect(state.totalExecuted).toBe(1);
+
+    expect(markChildStatus(state, "tool:part_1", "done", "2026-04-30T10:03:00.000Z")).toBe(
+      true,
+    );
+    expect(state.children["tool:part_1"]).toMatchObject({
+      status: "done",
+      color: "green",
+      endedAt: "2026-04-30T10:03:00.000Z",
+    });
+    expect(getCounts(state)).toEqual({ running: 0, done: 1, error: 0 });
+  });
+
+  it("merges details, sanitizes tokens, and refreshes elapsed fields", () => {
+    useFrozenTime("2026-04-30T10:02:00.000Z");
+    const state = createEmptyState();
+    state.children.ses_child = child();
+
+    expect(
+      upsertChildDetails(state, "ses_child", {
+        title: "Better title",
+        summary: "Better title",
+        agentName: "(planner)",
+        tokens: { input: 10, output: 5, contextPercent: 33.3 },
+      }),
+    ).toBe(true);
+    refreshDerivedFields(state);
+
+    expect(state.children.ses_child).toMatchObject({
+      title: "Better title",
+      summary: undefined,
+      agentName: "planner",
+      elapsedMs: 120000,
+      tokens: { input: 10, output: 5, contextPercent: 33.3 },
+    });
+  });
+
+  it("prunes old terminal children without losing running children", () => {
+    const state = createEmptyState();
+    state.children.running = child({ id: "running" });
+    state.children.oldDone = child({
+      id: "oldDone",
+      status: "done",
+      color: "green",
+      endedAt: "2026-04-30T08:00:00.000Z",
+      updatedAt: "2026-04-30T08:00:00.000Z",
+    });
+    state.children.recentDone = child({
+      id: "recentDone",
+      status: "done",
+      color: "green",
+      endedAt: "2026-04-30T09:30:00.000Z",
+      updatedAt: "2026-04-30T09:30:00.000Z",
+    });
+
+    expect(pruneTerminalChildren(state, new Date("2026-04-30T10:00:01.000Z"))).toBe(1);
+    expect(Object.keys(state.children).sort()).toEqual(["recentDone", "running"]);
+  });
+
+  it("resolves env paths and preserve-state flag", async () => {
+    const harness = await createRuntimeHarness({ preserveState: true });
+
+    expect(resolveStatePath()).toBe(harness.statePath);
+    expect(resolveTextPath(harness.statePath)).toBe(harness.textPath);
+    expect(shouldPreserveStateOnStartup()).toBe(true);
+  });
+
+  it("saves and loads state safely, falling back on invalid JSON", async () => {
+    const harness = await createRuntimeHarness();
+    const state = createEmptyState();
+    state.children.ses_child = child();
+    state.totalExecuted = 1;
+    state.countedChildIDs.ses_child = true;
+
+    await saveState(harness.statePath, state);
+    expect(await readRuntimeState(harness.statePath)).toMatchObject({ totalExecuted: 1 });
+    expect(await loadState(harness.statePath)).toMatchObject({ totalExecuted: 1 });
+
+    const badPath = join(harness.dir, "nested", "bad.json");
+    await mkdir(dirname(badPath), { recursive: true });
+    await writeFile(badPath, "not json", "utf8");
+    expect(await loadState(badPath)).toMatchObject({ children: {}, totalExecuted: 0 });
+  });
+});

--- a/test/fixtures/events/malformed.json
+++ b/test/fixtures/events/malformed.json
@@ -1,0 +1,7 @@
+{
+  "type": 42,
+  "properties": {
+    "part": "not-an-object",
+    "info": null
+  }
+}

--- a/test/fixtures/events/session-created.json
+++ b/test/fixtures/events/session-created.json
@@ -1,0 +1,14 @@
+{
+  "type": "session.created",
+  "properties": {
+    "info": {
+      "id": "ses_child_1",
+      "parentID": "ses_parent_1",
+      "title": "Review auth changes",
+      "agent": "reviewer",
+      "time": {
+        "created": "2026-04-30T10:00:00.000Z"
+      }
+    }
+  }
+}

--- a/test/fixtures/events/tool-updated.json
+++ b/test/fixtures/events/tool-updated.json
@@ -1,0 +1,30 @@
+{
+  "type": "message.part.updated",
+  "properties": {
+    "title": "Delegation: tester",
+    "part": {
+      "type": "tool",
+      "tool": "delegate",
+      "id": "part_1",
+      "sessionID": "ses_parent_1",
+      "messageID": "msg_1",
+      "state": {
+        "status": "running",
+        "input": {
+          "description": "Investigate flaky tests",
+          "subagent_type": "tester",
+          "prompt": "Investigate why tests are flaky and report findings. Include commands run."
+        },
+        "time": {
+          "started": "2026-04-30T10:01:00.000Z",
+          "updated": "2026-04-30T10:02:00.000Z"
+        },
+        "usage": {
+          "inputTokens": 1000,
+          "outputTokens": 250,
+          "contextPercent": 0.42
+        }
+      }
+    }
+  }
+}

--- a/test/helpers/runtime-harness.ts
+++ b/test/helpers/runtime-harness.ts
@@ -1,0 +1,59 @@
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { vi } from "vitest";
+
+const tempDirs = new Set<string>();
+
+export async function createRuntimeHarness(options: { preserveState?: boolean } = {}) {
+  const dir = await mkdtemp(join(tmpdir(), "subagent-statusline-test-"));
+  tempDirs.add(dir);
+
+  const statePath = join(dir, "state.json");
+  const textPath = join(dir, "status.txt");
+  process.env.OPENCODE_SUBAGENT_STATUSLINE_STATE = statePath;
+  process.env.OPENCODE_SUBAGENT_STATUSLINE_PRESERVE_STATE = options.preserveState
+    ? "1"
+    : "0";
+  process.env.NO_COLOR = "1";
+
+  return { dir, statePath, textPath };
+}
+
+export async function cleanupRegisteredTempDirs(): Promise<void> {
+  await Promise.all(
+    [...tempDirs].map(async (dir) => {
+      await rm(dir, { force: true, recursive: true });
+      tempDirs.delete(dir);
+    }),
+  );
+}
+
+export async function readJsonFixture<T>(name: string): Promise<T> {
+  const url = new URL(`../fixtures/events/${name}.json`, import.meta.url);
+  return JSON.parse(await readFile(url, "utf8")) as T;
+}
+
+export async function readRuntimeState<T>(statePath: string): Promise<T> {
+  return JSON.parse(await readFile(statePath, "utf8")) as T;
+}
+
+export async function readStatusText(textPath: string): Promise<string> {
+  return readFile(textPath, "utf8");
+}
+
+export async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function useFrozenTime(isoTimestamp: string): Date {
+  const now = new Date(isoTimestamp);
+  vi.useFakeTimers();
+  vi.setSystemTime(now);
+  return now;
+}

--- a/test/index.integration.test.ts
+++ b/test/index.integration.test.ts
@@ -1,0 +1,67 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import { SubagentStatusline } from "../src/index.js";
+import type { StatuslineState } from "../src/state.js";
+import {
+  createRuntimeHarness,
+  pathExists,
+  readJsonFixture,
+  readRuntimeState,
+  readStatusText,
+} from "./helpers/runtime-harness.js";
+
+async function createPlugin() {
+  return SubagentStatusline({} as Parameters<typeof SubagentStatusline>[0]);
+}
+
+describe("SubagentStatusline runtime", () => {
+  it("initializes empty runtime files and persists supported event changes", async () => {
+    const harness = await createRuntimeHarness();
+    const plugin = await createPlugin();
+    const event = await readJsonFixture("session-created");
+
+    expect(await readStatusText(harness.textPath)).toBe("↳ 0 running · 0 done · 0 error · Σ 0 total");
+
+    await expect(plugin.event?.({ event } as never)).resolves.toBeUndefined();
+
+    const state = await readRuntimeState<StatuslineState>(harness.statePath);
+    expect(state.children.ses_child_1).toMatchObject({
+      title: "Review auth changes",
+      status: "running",
+    });
+    expect(await readStatusText(harness.textPath)).toContain("Review auth changes");
+  });
+
+  it("preserves startup state when preserve-state is enabled", async () => {
+    const harness = await createRuntimeHarness({ preserveState: true });
+    await writeFile(
+      harness.statePath,
+      JSON.stringify({
+        children: {},
+        countedChildIDs: { existing: true },
+        totalExecuted: 7,
+        updatedAt: "2026-04-30T10:00:00.000Z",
+      }),
+      "utf8",
+    );
+
+    await createPlugin();
+
+    expect(await readRuntimeState<StatuslineState>(harness.statePath)).toMatchObject({
+      totalExecuted: 7,
+      countedChildIDs: { existing: true },
+    });
+    expect(await pathExists(harness.textPath)).toBe(false);
+  });
+
+  it("handles malformed events and write failures without throwing", async () => {
+    const harness = await createRuntimeHarness({ preserveState: true });
+    await mkdir(harness.statePath, { recursive: true });
+    const plugin = await createPlugin();
+    const malformed = await readJsonFixture("malformed");
+    const valid = await readJsonFixture("session-created");
+
+    await expect(plugin.event?.({ event: malformed } as never)).resolves.toBeUndefined();
+    await expect(plugin.event?.({ event: valid } as never)).resolves.toBeUndefined();
+  });
+});

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,32 @@
+import { afterEach } from "vitest";
+import { cleanupRegisteredTempDirs } from "./helpers/runtime-harness.js";
+
+const envKeys = [
+  "NO_COLOR",
+  "OPENCODE_SUBAGENT_STATUSLINE_COLOR",
+  "OPENCODE_SUBAGENT_STATUSLINE_INSTANCE",
+  "OPENCODE_SUBAGENT_STATUSLINE_PRESERVE_STATE",
+  "OPENCODE_SUBAGENT_STATUSLINE_STATE",
+  "XDG_RUNTIME_DIR",
+];
+
+const originalEnv = new Map(
+  envKeys.map((key) => [key, process.env[key]]),
+);
+
+afterEach(async () => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+
+  for (const key of envKeys) {
+    const original = originalEnv.get(key);
+    if (original === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = original;
+    }
+  }
+
+  await cleanupRegisteredTempDirs();
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,6 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx"]
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.test.ts", "test/**/*.ts", "vitest.config.ts"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    setupFiles: ["./test/setup.ts"],
+    include: ["src/**/*.test.ts", "test/**/*.integration.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts", "src/tui.tsx"],
+    },
+  },
+});


### PR DESCRIPTION
Closes #32

## PR Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [x] Maintenance/tooling
- [ ] Breaking change

## Summary
- Add Vitest test infrastructure and coverage tooling for the plugin.
- Add unit tests for events/state/render plus runtime integration tests.
- Document the testing strategy and add PR CI for typecheck + tests.

## Changes
| File | Change |
|------|--------|
| `package.json`, `pnpm-lock.yaml` | Add Vitest dependencies and test scripts |
| `vitest.config.ts`, `tsconfig.test.json`, `test/setup.ts` | Add test configuration and setup |
| `src/*.test.ts` | Add unit coverage for event parsing, state invariants, and rendering |
| `test/index.integration.test.ts`, `test/helpers/*`, `test/fixtures/*` | Add runtime integration harness and fixtures |
| `.github/workflows/ci.yml` | Add PR CI for typecheck and tests |
| `README.md`, `docs/testing.md` | Document testing commands and strategy |

## Test Plan
- [x] `pnpm typecheck`
- [x] `pnpm exec tsc --noEmit -p tsconfig.test.json`
- [x] `pnpm test`
- [x] `pnpm test:coverage`
- [x] No shell scripts modified; shellcheck not applicable

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts / N/A, no shell scripts modified
- [x] Skills tested in at least one agent / N/A, no skills modified
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers