### PR TITLE
fix(tui): improve plugin status reconciliation

### DIFF
--- a/src/events.test.ts
+++ b/src/events.test.ts
@@ -88,6 +88,92 @@ describe("events", () => {
     expect(applySubagentEvent(state, null)).toBe(false);
     expect(state.children).toEqual({});
   });
+
+  it("maps session.status idle evidence to done", () => {
+    const state = createEmptyState();
+    applySubagentEvent(state, {
+      type: "session.created",
+      properties: {
+        info: {
+          id: "ses_child_status",
+          parentID: "ses_parent",
+          title: "Child status",
+          time: { created: "2026-05-10T10:00:00.000Z" },
+        },
+      },
+    });
+
+    const changed = applySubagentEvent(state, {
+      type: "session.status",
+      properties: {
+        sessionID: "ses_child_status",
+        status: "idle",
+        info: { time: { updated: "2026-05-10T10:15:00.000Z" } },
+      },
+    });
+
+    expect(changed).toBe(true);
+    expect(state.children.ses_child_status).toMatchObject({
+      status: "done",
+      endedAt: "2026-05-10T10:15:00.000Z",
+    });
+  });
+
+  it.each(["busy", "retry"])(
+    "keeps a running child active for session.status %s",
+    (status) => {
+      const state = createEmptyState();
+      applySubagentEvent(state, {
+        type: "session.created",
+        properties: {
+          info: {
+            id: "ses_child_running",
+            parentID: "ses_parent",
+            title: "Child running",
+          },
+        },
+      });
+
+      applySubagentEvent(state, {
+        type: "session.status",
+        properties: {
+          sessionID: "ses_child_running",
+          status,
+        },
+      });
+
+      expect(state.children.ses_child_running?.status).toBe("running");
+      expect(state.children.ses_child_running?.endedAt).toBeUndefined();
+    },
+  );
+
+  it("maps session.status terminal errors to error", () => {
+    const state = createEmptyState();
+    applySubagentEvent(state, {
+      type: "session.created",
+      properties: {
+        info: {
+          id: "ses_child_error",
+          parentID: "ses_parent",
+          title: "Child error",
+        },
+      },
+    });
+
+    applySubagentEvent(state, {
+      type: "session.status",
+      properties: {
+        sessionID: "ses_child_error",
+        status: "failed",
+        info: { time: { updated: "2026-05-10T10:20:00.000Z" } },
+      },
+    });
+
+    expect(state.children.ses_child_error).toMatchObject({
+      status: "error",
+      endedAt: "2026-05-10T10:20:00.000Z",
+    });
+  });
 });
 
 describe("extractTaskToolEvidence", () => {

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,4 +1,5 @@
 import type { ChildTokenState, StatuslineState } from "./state.js";
+import { deriveOpenCodeSessionStatus } from "./reconcile.js";
 import { markChildStatus, upsertChildDetails, upsertRunningChild } from "./state.js";
 
 export type EventLike = {
@@ -7,6 +8,8 @@ export type EventLike = {
   name?: unknown;
   sessionID?: unknown;
   sessionId?: unknown;
+  status?: unknown;
+  state?: unknown;
   properties?: {
     id?: unknown;
     sessionID?: unknown;
@@ -24,9 +27,13 @@ export type EventLike = {
       parentID?: unknown;
       role?: unknown;
       time?: unknown;
+      status?: unknown;
+      state?: unknown;
     };
     parentID?: unknown;
     part?: unknown;
+    status?: unknown;
+    state?: unknown;
   };
   parentID?: unknown;
   [key: string]: unknown;
@@ -700,6 +707,30 @@ export function applySubagentEvent(state: StatuslineState, event: unknown): bool
     const endedAt = extractEventTimestamp(e, ["completed", "end", "ended", "updated"]);
     const details = extractChildDetails(e);
     let changed = markChildStatus(state, childID, "error", endedAt);
+    changed = upsertChildDetails(state, childID, details) || changed;
+    return changed;
+  }
+
+  if (type === "session.status") {
+    const childID = extractSessionID(e);
+    if (!childID) return false;
+    const status = deriveOpenCodeSessionStatus(
+      e.properties?.status ??
+        e.properties?.state ??
+        e.properties?.info?.status ??
+        e.status ??
+        e.state ??
+        e.properties,
+    );
+    if (!status) return false;
+
+    const endedAt =
+      status === "done" || status === "error"
+        ? extractEventTimestamp(e, ["completed", "end", "ended", "updated"])
+        : undefined;
+    const details = extractChildDetails(e);
+    let changed =
+      status === "running" ? false : markChildStatus(state, childID, status, endedAt);
     changed = upsertChildDetails(state, childID, details) || changed;
     return changed;
   }

--- a/src/reconcile.test.ts
+++ b/src/reconcile.test.ts
@@ -2,14 +2,51 @@ import { describe, expect, it } from "vitest";
 import {
   canSafelyCloseNoTargetPersistedCandidate,
   capCandidates,
+  defaultStaleRunningThresholdMs,
+  deriveOpenCodeSessionStatus,
   hasRecentMessageActivity,
   nextBackoffState,
+  parseStaleRunningThresholdMs,
   resolvePersistedStaleSubtaskFromParentMessages,
   shouldApplyStaleRunningFallback,
   shouldSkipCandidateForBackoff,
   summarizeSessionMessages,
   type RunningReconcileEvidence,
 } from "./reconcile.js";
+
+describe("OpenCode session status normalization", () => {
+  it.each([
+    ["idle", "done"],
+    ["done", "done"],
+    ["completed", "done"],
+    ["success", "done"],
+    ["succeeded", "done"],
+    ["error", "error"],
+    ["failed", "error"],
+    ["cancelled", "error"],
+    ["aborted", "error"],
+    ["busy", "running"],
+    ["running", "running"],
+    ["pending", "running"],
+    ["queued", "running"],
+    ["in_progress", "running"],
+    ["working", "running"],
+    ["compacting", "running"],
+    ["retry", "running"],
+  ] as const)("maps %s to %s", (raw, expected) => {
+    expect(deriveOpenCodeSessionStatus(raw)).toBe(expected);
+  });
+
+  it("maps object-shaped evidence and leaves unknown values inconclusive", () => {
+    expect(deriveOpenCodeSessionStatus({ status: "working" })).toBe("running");
+    expect(deriveOpenCodeSessionStatus({ state: "idle" })).toBe("done");
+    expect(deriveOpenCodeSessionStatus({ error: { message: "boom" } })).toBe(
+      "error",
+    );
+    expect(deriveOpenCodeSessionStatus({ status: "mystery" })).toBeUndefined();
+    expect(deriveOpenCodeSessionStatus(undefined)).toBeUndefined();
+  });
+});
 
 describe("reconcile fail-closed fallback gating", () => {
   it("does not allow stale fallback when probes fail or are inconclusive", () => {
@@ -82,6 +119,18 @@ describe("terminal positive evidence", () => {
 });
 
 describe("stale fallback thresholds", () => {
+  it("defaults to approximately 10 hours and preserves override semantics", () => {
+    expect(defaultStaleRunningThresholdMs()).toBe(10 * 60 * 60_000);
+    expect(parseStaleRunningThresholdMs(undefined)).toBe(
+      defaultStaleRunningThresholdMs(),
+    );
+    expect(parseStaleRunningThresholdMs("not-a-number")).toBe(
+      defaultStaleRunningThresholdMs(),
+    );
+    expect(parseStaleRunningThresholdMs("1234.9")).toBe(1234);
+    expect(parseStaleRunningThresholdMs("0")).toBe(0);
+  });
+
   it("applies fallback only after threshold and only when probes succeeded", () => {
     const staleThresholdMs = 10_000;
     const succeeded: RunningReconcileEvidence = {
@@ -311,7 +360,7 @@ describe("persisted stale subtask recovery evidence", () => {
 describe("no-target persisted stale fallback safety", () => {
   it("allows closure only when stale and with no recent parent activity", () => {
     const nowMs = Date.now();
-    const staleThresholdMs = 24 * 60 * 60_000;
+    const staleThresholdMs = defaultStaleRunningThresholdMs();
 
     expect(
       canSafelyCloseNoTargetPersistedCandidate({
@@ -330,6 +379,15 @@ describe("no-target persisted stale fallback safety", () => {
         startedMs: staleThresholdMs + 1,
         updatedMs: staleThresholdMs + 1,
         latestMessageActivityAtMs: nowMs - 1_000,
+      }),
+    ).toBe(false);
+
+    expect(
+      canSafelyCloseNoTargetPersistedCandidate({
+        nowMs,
+        staleThresholdMs: 0,
+        startedMs: staleThresholdMs + 1,
+        updatedMs: staleThresholdMs + 1,
       }),
     ).toBe(false);
   });

--- a/src/reconcile.ts
+++ b/src/reconcile.ts
@@ -12,6 +12,76 @@ export type RunningReconcileEvidence = {
   canApplyStaleFallback?: boolean;
 };
 
+export type OpenCodeSessionChildStatus = "running" | "done" | "error";
+
+const DEFAULT_STALE_RUNNING_THRESHOLD_MS = 10 * 60 * 60_000;
+
+const RUNNING_SESSION_STATUS_VALUES = new Set([
+  "busy",
+  "running",
+  "pending",
+  "queued",
+  "in_progress",
+  "working",
+  "compacting",
+  "retry",
+]);
+
+const DONE_SESSION_STATUS_VALUES = new Set([
+  "idle",
+  "done",
+  "completed",
+  "complete",
+  "success",
+  "succeeded",
+]);
+
+const ERROR_SESSION_STATUS_VALUES = new Set([
+  "error",
+  "failed",
+  "failure",
+  "cancelled",
+  "canceled",
+  "aborted",
+]);
+
+export function defaultStaleRunningThresholdMs(): number {
+  return DEFAULT_STALE_RUNNING_THRESHOLD_MS;
+}
+
+export function parseStaleRunningThresholdMs(value: unknown): number {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return DEFAULT_STALE_RUNNING_THRESHOLD_MS;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return DEFAULT_STALE_RUNNING_THRESHOLD_MS;
+  }
+
+  return Math.floor(parsed);
+}
+
+export function deriveOpenCodeSessionStatus(
+  value: unknown,
+): OpenCodeSessionChildStatus | undefined {
+  const values = collectOpenCodeSessionStatusValues(value);
+
+  if (values.some((status) => ERROR_SESSION_STATUS_VALUES.has(status))) {
+    return "error";
+  }
+
+  if (values.some((status) => RUNNING_SESSION_STATUS_VALUES.has(status))) {
+    return "running";
+  }
+
+  if (values.some((status) => DONE_SESSION_STATUS_VALUES.has(status))) {
+    return "done";
+  }
+
+  return undefined;
+}
+
 export type PersistedStaleSubtaskCandidate = {
   childID: string;
   parentID: string;
@@ -294,6 +364,35 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === "object"
     ? (value as Record<string, unknown>)
     : undefined;
+}
+
+function collectOpenCodeSessionStatusValues(value: unknown): string[] {
+  if (typeof value === "string") {
+    const normalized = normalizeStatusValue(value);
+    return normalized ? [normalized] : [];
+  }
+
+  const record = asRecord(value);
+  if (!record) return [];
+
+  const values = [
+    normalizeStatusValue(record.type),
+    normalizeStatusValue(record.status),
+    normalizeStatusValue(record.state),
+    normalizeStatusValue(record.phase),
+    normalizeStatusValue(record.result),
+  ].filter((status): status is string => Boolean(status));
+
+  if (record.error) values.push("error");
+  if (record.busy === true || record.running === true) values.push("busy");
+
+  return values;
+}
+
+function normalizeStatusValue(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase();
+  return normalized.length > 0 ? normalized : undefined;
 }
 
 function asString(value: unknown): string | undefined {

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -39,8 +39,10 @@ import {
 import {
   canSafelyCloseNoTargetPersistedCandidate,
   capCandidates,
+  deriveOpenCodeSessionStatus,
   hasRecentMessageActivity,
   nextBackoffState,
+  parseStaleRunningThresholdMs as parseConfiguredStaleRunningThresholdMs,
   resolvePersistedStaleSubtaskFromParentMessages,
   shouldApplyStaleRunningFallback,
   shouldSkipCandidateForBackoff,
@@ -78,7 +80,6 @@ const RUNNING_RECONCILE_INITIAL_BACKOFF_MS = 15_000;
 const RUNNING_RECONCILE_MAX_BACKOFF_MS = 5 * 60_000;
 const RUNNING_RECONCILE_MESSAGE_AGE_GATE_MS = 60_000;
 const RUNNING_RECONCILE_OLD_CANDIDATE_AGE_MS = 5 * 60_000;
-const DEFAULT_STALE_RUNNING_THRESHOLD_MS = 24 * 60 * 60_000;
 const CLOCK_ICON = "";
 const TOKEN_ICON = "";
 const SIDEBAR_ARROW_EXPANDED = "▼";
@@ -664,17 +665,9 @@ function toFinitePositiveInt(value: unknown): number | undefined {
 }
 
 function parseStaleRunningThresholdMs(): number {
-  const raw = process.env.OPENCODE_SUBAGENT_STATUSLINE_STALE_RUNNING_MS;
-  if (typeof raw !== "string" || raw.trim().length === 0) {
-    return DEFAULT_STALE_RUNNING_THRESHOLD_MS;
-  }
-
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0) {
-    return DEFAULT_STALE_RUNNING_THRESHOLD_MS;
-  }
-
-  return Math.floor(parsed);
+  return parseConfiguredStaleRunningThresholdMs(
+    process.env.OPENCODE_SUBAGENT_STATUSLINE_STALE_RUNNING_MS,
+  );
 }
 
 const STALE_RUNNING_THRESHOLD_MS = parseStaleRunningThresholdMs();
@@ -1569,7 +1562,7 @@ async function hydratePreviousSubagents(
         };
         if (applySubagentEvent(next, fakeEvent)) changed = true;
 
-        const status = asRecord(allStatuses[session.id]);
+        const status = allStatuses[session.id];
         const sessionStatus = deriveSessionChildStatus(status);
         const childSummary = childMessageSummaryByID.get(session.id);
         const explicitCompletionEvidence =
@@ -1684,70 +1677,10 @@ async function safeReadAsync<Value>(
   }
 }
 
-function normalizedSessionStatusValue(value: unknown): string | undefined {
-  if (typeof value !== "string") return undefined;
-  const normalized = value.trim().toLowerCase();
-  return normalized.length > 0 ? normalized : undefined;
-}
-
 function deriveSessionChildStatus(
-  status: Record<string, unknown> | undefined,
+  status: unknown,
 ): ChildSessionState["status"] | undefined {
-  if (!status) return undefined;
-
-  if (status.error) return "error";
-
-  const values = [
-    normalizedSessionStatusValue(status.type),
-    normalizedSessionStatusValue(status.status),
-    normalizedSessionStatusValue(status.state),
-    normalizedSessionStatusValue(status.phase),
-    normalizedSessionStatusValue(status.result),
-  ].filter((value): value is string => Boolean(value));
-
-  if (status.busy === true || status.running === true) {
-    values.push("busy");
-  }
-
-  if (
-    values.some((value) =>
-      [
-        "error",
-        "failed",
-        "failure",
-        "cancelled",
-        "canceled",
-        "aborted",
-      ].includes(value),
-    )
-  ) {
-    return "error";
-  }
-
-  if (
-    values.some((value) =>
-      ["busy", "running", "pending", "queued", "in_progress"].includes(value),
-    )
-  ) {
-    return "running";
-  }
-
-  if (
-    values.some((value) =>
-      [
-        "done",
-        "completed",
-        "complete",
-        "success",
-        "succeeded",
-        "idle",
-      ].includes(value),
-    )
-  ) {
-    return "done";
-  }
-
-  return undefined;
+  return deriveOpenCodeSessionStatus(status);
 }
 
 function sessionTimestamp(
@@ -1887,7 +1820,7 @@ async function probeRunningEvidence(input: {
     input.api.state.session.status(input.targetSessionID),
   );
   if (directStatus === undefined) probeFailed = true;
-  const statusFromState = deriveSessionChildStatus(asRecord(directStatus));
+  const statusFromState = deriveSessionChildStatus(directStatus);
   if (statusFromState === "done" || statusFromState === "error") {
     return { status: statusFromState, endedAt: new Date().toISOString() };
   }
@@ -1900,9 +1833,7 @@ async function probeRunningEvidence(input: {
   );
   if (statusResp === undefined) probeFailed = true;
   const statuses = asRecord(statusResp?.data);
-  const statusFromClient = deriveSessionChildStatus(
-    asRecord(statuses?.[input.targetSessionID]),
-  );
+  const statusFromClient = deriveSessionChildStatus(statuses?.[input.targetSessionID]);
   if (statusFromClient === "done" || statusFromClient === "error") {
     return { status: statusFromClient, endedAt: new Date().toISOString() };
   }
@@ -2517,6 +2448,7 @@ const tui: TuiPlugin = async (api: TuiPluginApi) => {
   const disposers = [
     api.event.on("session.created", applyEvent),
     api.event.on("session.updated", applyEvent),
+    api.event.on("session.status", applyEvent),
     api.event.on("session.idle", applyEvent),
     api.event.on("session.error", applyEvent),
     api.event.on("message.updated", applyEvent),

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -175,6 +175,7 @@ type HomePromptProps = {
 type SessionPromptProps = {
   sessionID?: string;
   session_id?: string;
+  right?: unknown;
   visible?: boolean;
   disabled?: boolean;
   onSubmit?: () => void;
@@ -2075,7 +2076,7 @@ const tui: TuiPlugin = async (api: TuiPluginApi) => {
     }, 0);
   };
 
-  const commandDispose = api.command.register(() => [
+  const commandDispose = api.command?.register?.(() => [
     {
       title: subagentsSectionEnabled()
         ? "Subagents: Disable sidebar section"
@@ -2094,7 +2095,7 @@ const tui: TuiPlugin = async (api: TuiPluginApi) => {
       keybind: "alt+b",
       onSelect: toggleSidebarListFocus,
     },
-  ]);
+  ]) ?? (() => undefined);
 
   const clearHydrateRetryTimeout = (sessionID: string): void => {
     const timeout = hydrateRetryTimeouts.get(sessionID);
@@ -2583,6 +2584,7 @@ const tui: TuiPlugin = async (api: TuiPluginApi) => {
         return <api.ui.Prompt {...promptProps} />;
       },
       session_prompt(_ctx: TuiSlotContext, props: SessionPromptProps) {
+        const sessionID = props.sessionID ?? props.session_id;
         const promptProps = {
           ...props,
           ...(props.sessionID === undefined && props.session_id !== undefined
@@ -2591,6 +2593,14 @@ const tui: TuiPlugin = async (api: TuiPluginApi) => {
           ...(props.onSubmit === undefined && props.on_submit !== undefined
             ? { onSubmit: props.on_submit }
             : {}),
+          right:
+            props.right ??
+            (sessionID ? (
+              <api.ui.Slot
+                name="session_prompt_right"
+                session_id={sessionID}
+              />
+            ) : undefined),
           ref: composePromptRef(props.ref),
         };
         return <api.ui.Prompt {...promptProps} />;


### PR DESCRIPTION
## Summary

- Preserve prompt-right compatibility so plugins like `oc-tps` can continue rendering `session_prompt_right`.
- Avoid initialization crashes when OpenCode does not expose `api.command.register`.
- Add status-aware reconciliation for stale running subagents, including `session.status`, direct status strings, and a guarded 10h fallback.

Closes #43
Closes #44
Closes #45

## Validation

- [x] `./node_modules/.bin/tsc --noEmit -p tsconfig.json`
- [x] `./node_modules/.bin/vitest run` — 59 tests passed
- [x] Manual local plugin smoke test reported working

## Checklist

- [x] I used a Conventional Commit title (e.g. `fix: ...`, `feat: ...`, `docs: ...`)
- [x] I linked related issue(s), or explained why none are needed
- [x] I did not include secrets, credentials, or private data
- [x] I called out any security-sensitive behavior changes
- [x] I updated docs when behavior or usage changed

Security-sensitive behavior changes: none.
Docs update: not needed; behavior is internal bugfix/reconciliation compatibility.