### PR TITLE
fix(tui): remove OpenCode deprecation and Solid lifecycle warnings

### DIFF
--- a/src/tui-commands.ts
+++ b/src/tui-commands.ts
@@ -1,0 +1,105 @@
+export type TuiCommandDispose = () => void;
+
+type LegacyCommand = {
+  title: string;
+  value: string;
+  description?: string;
+  category?: string;
+  keybind?: string;
+  onSelect?: () => void;
+};
+
+type LegacyCommandApi = {
+  register?: (commands: () => LegacyCommand[]) => TuiCommandDispose;
+};
+
+type KeymapCommand = {
+  name: string;
+  title: string;
+  description?: string;
+  category?: string;
+  run: () => void;
+};
+
+type KeymapBinding = {
+  key: string;
+  cmd: string;
+};
+
+type KeymapLayer = {
+  commands: KeymapCommand[];
+  bindings: KeymapBinding[];
+};
+
+type KeymapApi = {
+  registerLayer?: (layer: KeymapLayer) => TuiCommandDispose;
+};
+
+type CommandApiShape = {
+  keymap?: KeymapApi;
+  command?: LegacyCommandApi;
+};
+
+type RegisterSubagentCommandsInput = {
+  api: CommandApiShape;
+  sectionEnabled: () => boolean;
+  toggleSection: (enabled: boolean) => void;
+  focusSidebarList: () => void;
+};
+
+const TOGGLE_SECTION_COMMAND = "subagent-statusline.toggle-sidebar-section";
+const FOCUS_SIDEBAR_LIST_COMMAND = "subagent-statusline.focus-sidebar-list";
+
+export function registerSubagentCommands({
+  api,
+  sectionEnabled,
+  toggleSection,
+  focusSidebarList,
+}: RegisterSubagentCommandsInput): TuiCommandDispose {
+  if (api.keymap?.registerLayer) {
+    return api.keymap.registerLayer({
+      commands: [
+        {
+          name: TOGGLE_SECTION_COMMAND,
+          title: "Subagents: Toggle sidebar section",
+          description: "Toggle the entire subagent sidebar section",
+          category: "Subagents",
+          run: () => toggleSection(!sectionEnabled()),
+        },
+        {
+          name: FOCUS_SIDEBAR_LIST_COMMAND,
+          title: "Subagents: Focus sidebar list",
+          description: "Focus the subagent sidebar list for keyboard navigation",
+          category: "Subagents",
+          run: focusSidebarList,
+        },
+      ],
+      bindings: [
+        {
+          key: "alt+b",
+          cmd: FOCUS_SIDEBAR_LIST_COMMAND,
+        },
+      ],
+    });
+  }
+
+  return api.command?.register?.(() => [
+    {
+      title: sectionEnabled()
+        ? "Subagents: Disable sidebar section"
+        : "Subagents: Enable sidebar section",
+      value: TOGGLE_SECTION_COMMAND,
+      description: "Toggle the entire subagent sidebar section",
+      category: "Subagents",
+      onSelect: () => toggleSection(!sectionEnabled()),
+    },
+    {
+      title: "Subagents: Focus sidebar list",
+      value: FOCUS_SIDEBAR_LIST_COMMAND,
+      description: "Focus the subagent sidebar list for keyboard navigation",
+      category: "Subagents",
+      keybind: "alt+b",
+      onSelect: focusSidebarList,
+    },
+  ]) ?? (() => undefined);
+}

--- a/src/tui.test.ts
+++ b/src/tui.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import { registerSubagentCommands } from "./tui-commands.js";
+
+describe("registerSubagentCommands", () => {
+  it("uses the supported keymap layer API when available", () => {
+    const dispose = vi.fn();
+    const registerLayer = vi.fn(() => dispose);
+    const commandRegister = vi.fn();
+    const toggleSection = vi.fn();
+    const focusSidebarList = vi.fn();
+
+    const result = registerSubagentCommands({
+      api: {
+        keymap: { registerLayer },
+        command: { register: commandRegister },
+      },
+      sectionEnabled: () => true,
+      toggleSection,
+      focusSidebarList,
+    });
+
+    expect(commandRegister).not.toHaveBeenCalled();
+    expect(registerLayer).toHaveBeenCalledOnce();
+    expect(registerLayer).toHaveBeenCalledWith({
+      commands: [
+        expect.objectContaining({
+          name: "subagent-statusline.toggle-sidebar-section",
+          title: expect.stringContaining("Subagents"),
+          run: expect.any(Function),
+        }),
+        expect.objectContaining({
+          name: "subagent-statusline.focus-sidebar-list",
+          title: "Subagents: Focus sidebar list",
+          run: expect.any(Function),
+        }),
+      ],
+      bindings: [
+        {
+          key: "alt+b",
+          cmd: "subagent-statusline.focus-sidebar-list",
+        },
+      ],
+    });
+
+    const layer = registerLayer.mock.calls[0]?.[0];
+    layer?.commands?.[0]?.run();
+    layer?.commands?.[1]?.run();
+
+    expect(toggleSection).toHaveBeenCalledWith(false);
+    expect(focusSidebarList).toHaveBeenCalledOnce();
+
+    result();
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to the legacy command API only when keymap is unavailable", () => {
+    const dispose = vi.fn();
+    const register = vi.fn(() => dispose);
+
+    const result = registerSubagentCommands({
+      api: { command: { register } },
+      sectionEnabled: () => false,
+      toggleSection: vi.fn(),
+      focusSidebarList: vi.fn(),
+    });
+
+    expect(register).toHaveBeenCalledOnce();
+    result();
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+});

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -23,6 +23,7 @@ import { dirname, join } from "node:path";
 import {
   For,
   Show,
+  createRoot,
   createEffect,
   createMemo,
   createSignal,
@@ -63,6 +64,7 @@ import {
   type ChildSessionState,
   type StatuslineState,
 } from "./state.js";
+import { registerSubagentCommands } from "./tui-commands.js";
 
 const TUI_PLUGIN_ID = "subagent-statusline.tui";
 const ELAPSED_TICK_MS = 1000;
@@ -1902,7 +1904,7 @@ async function probeRunningEvidence(input: {
   };
 }
 
-const tui: TuiPlugin = async (api: TuiPluginApi) => {
+function initializeTui(api: TuiPluginApi, disposeRoot: () => void): void {
   const statePath = resolveStatePath();
   const textPath = resolveTextPath(statePath);
   const [state, setState] = createSignal<StatuslineState>(createEmptyState());
@@ -2007,26 +2009,12 @@ const tui: TuiPlugin = async (api: TuiPluginApi) => {
     }, 0);
   };
 
-  const commandDispose = api.command?.register?.(() => [
-    {
-      title: subagentsSectionEnabled()
-        ? "Subagents: Disable sidebar section"
-        : "Subagents: Enable sidebar section",
-      value: "subagent-statusline.toggle-sidebar-section",
-      description: "Toggle the entire subagent sidebar section",
-      category: "Subagents",
-      onSelect: () =>
-        setSubagentsSectionEnabledPreference(!subagentsSectionEnabled()),
-    },
-    {
-      title: "Subagents: Focus sidebar list",
-      value: "subagent-statusline.focus-sidebar-list",
-      description: "Focus the subagent sidebar list for keyboard navigation",
-      category: "Subagents",
-      keybind: "alt+b",
-      onSelect: toggleSidebarListFocus,
-    },
-  ]) ?? (() => undefined);
+  const commandDispose = registerSubagentCommands({
+    api,
+    sectionEnabled: subagentsSectionEnabled,
+    toggleSection: setSubagentsSectionEnabledPreference,
+    focusSidebarList: toggleSidebarListFocus,
+  });
 
   const clearHydrateRetryTimeout = (sessionID: string): void => {
     const timeout = hydrateRetryTimeouts.get(sessionID);
@@ -2466,6 +2454,7 @@ const tui: TuiPlugin = async (api: TuiPluginApi) => {
     for (const dispose of disposers) {
       dispose();
     }
+    disposeRoot();
   });
 
   api.slots.register({
@@ -2539,6 +2528,10 @@ const tui: TuiPlugin = async (api: TuiPluginApi) => {
       },
     },
   });
+}
+
+const tui: TuiPlugin = async (api: TuiPluginApi) => {
+  createRoot((disposeRoot) => initializeTui(api, disposeRoot));
 };
 
 const plugin: TuiPluginModule = {


### PR DESCRIPTION
## Summary

Fixes the two OpenCode runtime warnings emitted on plugin load:

```
[WARN] '[tui.plugin] deprecated TUI plugin API' {
  api: 'api.command.register',
  replacement: 'api.keymap.registerLayer({ commands, bindings })'
}
[WARN] 'computations created outside a `createRoot` or `render` will never be disposed'
```

- Prefer `api.keymap.registerLayer({ commands, bindings })` for TUI command/keybind registration via a new `registerSubagentCommands` helper.
- Keep `api.command.register` as a fallback so older OpenCode versions keep working unchanged.
- Wrap TUI initialization in Solid `createRoot` and dispose the root through `api.lifecycle.onDispose` so signals/effects no longer leak.
- Add unit tests covering both the keymap-first path and the legacy fallback.

Fixes #47.

## Validation

- `pnpm vitest run src/tui.test.ts` — 2 passed.
- `pnpm test` — 61 passed across 6 files.
- `pnpm typecheck` — clean.
- `npm run build` — `dist/index.js` + `dist/tui.js` + declarations built without errors.
- Manual OpenCode test: warnings no longer appear on plugin load.

## Checklist

- [x] I used a Conventional Commit title (`fix(tui): ...`)
- [x] I linked related issue(s) — Fixes #47
- [x] I did not include secrets, credentials, or private data
- [x] I called out any security-sensitive behavior changes — none
- [x] I updated docs when behavior or usage changed — keybind/command names unchanged; no doc update needed