### PR TITLE
fix(state): deduplicate subagent execution counts

### DIFF
--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -397,4 +397,30 @@ describe("state", () => {
     expect(loaded.countedChildIDs.ses_child).toBe(true);
     expect(loaded.countedChildIDs["subtask:old"]).toBeUndefined();
   });
+
+  it("deduplicates historical subtask and target ids that were both counted", async () => {
+    const harness = await createRuntimeHarness();
+    await writeFile(
+      harness.statePath,
+      JSON.stringify({
+        children: {
+          "subtask:old": child({
+            id: "subtask:old",
+            source: "subtask",
+            targetSessionID: "ses_child",
+          }),
+        },
+        countedChildIDs: { "subtask:old": true, ses_child: true },
+        totalExecuted: 2,
+        updatedAt: "2026-04-30T10:00:00.000Z",
+      }),
+      "utf8",
+    );
+
+    const loaded = await loadState(harness.statePath);
+
+    expect(loaded.totalExecuted).toBe(1);
+    expect(loaded.countedChildIDs.ses_child).toBe(true);
+    expect(loaded.countedChildIDs["subtask:old"]).toBeUndefined();
+  });
 });

--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -38,7 +38,7 @@ function child(overrides: Partial<ChildSessionState> = {}): ChildSessionState {
 }
 
 describe("state", () => {
-  it("upserts running children, counts work once, and marks terminal statuses", () => {
+  it("upserts tool wrappers without counting them and marks terminal statuses", () => {
     useFrozenTime("2026-04-30T10:05:00.000Z");
     const state = createEmptyState();
 
@@ -51,27 +51,190 @@ describe("state", () => {
         startedAt: "2026-04-30T10:00:00.000Z",
       }),
     ).toBe(true);
-    expect(state.totalExecuted).toBe(1);
+    expect(state.totalExecuted).toBe(0);
+    expect(state.countedChildIDs["tool:part_1"]).toBeUndefined();
+    expect(state.children["tool:part_1"]).toBeDefined();
+
+    upsertRunningChild(state, {
+      id: "tool:part_1",
+      title: "Run tests",
+      parentID: "ses_parent",
+      source: "tool",
+      updatedAt: "2026-04-30T10:02:00.000Z",
+    });
+    expect(state.totalExecuted).toBe(0);
+    expect(state.countedChildIDs["tool:part_1"]).toBeUndefined();
 
     expect(
-      upsertRunningChild(state, {
-        id: "tool:part_1",
-        title: "Run tests",
-        parentID: "ses_parent",
-        source: "tool",
-      }),
-    ).toBe(false);
-    expect(state.totalExecuted).toBe(1);
-
-    expect(markChildStatus(state, "tool:part_1", "done", "2026-04-30T10:03:00.000Z")).toBe(
-      true,
-    );
+      markChildStatus(state, "tool:part_1", "done", "2026-04-30T10:03:00.000Z"),
+    ).toBe(true);
     expect(state.children["tool:part_1"]).toMatchObject({
       status: "done",
       color: "green",
       endedAt: "2026-04-30T10:03:00.000Z",
     });
+    expect(state.totalExecuted).toBe(0);
+    expect(state.countedChildIDs["tool:part_1"]).toBeUndefined();
     expect(getCounts(state)).toEqual({ running: 0, done: 1, error: 0 });
+  });
+
+  it("keeps non-zero-duration tool wrappers uncounted", () => {
+    const state = createEmptyState();
+
+    expect(
+      upsertRunningChild(state, {
+        id: "tool:part_2",
+        title: "Run longer delegated task",
+        parentID: "ses_parent",
+        source: "tool",
+        startedAt: "2026-04-30T10:00:00.000Z",
+        updatedAt: "2026-04-30T10:05:00.000Z",
+      }),
+    ).toBe(true);
+    markChildStatus(state, "tool:part_2", "done", "2026-04-30T10:05:00.000Z");
+    refreshDerivedFields(state, new Date("2026-04-30T10:05:00.000Z"));
+
+    expect(state.children["tool:part_2"].elapsedMs).toBe(300000);
+    expect(state.totalExecuted).toBe(0);
+    expect(state.countedChildIDs["tool:part_2"]).toBeUndefined();
+  });
+
+  it("counts real sessions exactly once even with repeated updates", () => {
+    const state = createEmptyState();
+
+    expect(
+      upsertRunningChild(state, {
+        id: "ses_child",
+        title: "Child work",
+        parentID: "ses_parent",
+        source: "session",
+      }),
+    ).toBe(true);
+    expect(state.totalExecuted).toBe(1);
+    expect(state.countedChildIDs.ses_child).toBe(true);
+
+    upsertRunningChild(state, {
+      id: "ses_child",
+      title: "Child work",
+      parentID: "ses_parent",
+      source: "session",
+      updatedAt: "2026-04-30T10:02:00.000Z",
+    });
+    expect(
+      markChildStatus(state, "ses_child", "done", "2026-04-30T10:03:00.000Z"),
+    ).toBe(true);
+
+    expect(state.totalExecuted).toBe(1);
+    expect(Object.keys(state.countedChildIDs)).toEqual(["ses_child"]);
+  });
+
+  it("counts a tool wrapper followed by a matching real session as one execution", () => {
+    const state = createEmptyState();
+
+    upsertRunningChild(state, {
+      id: "tool:part_1",
+      title: "Delegate work",
+      parentID: "ses_parent",
+      messageID: "msg_1",
+      source: "tool",
+      targetSessionID: "ses_child",
+    });
+    expect(state.totalExecuted).toBe(0);
+
+    upsertRunningChild(state, {
+      id: "ses_child",
+      title: "Child work",
+      parentID: "ses_parent",
+      messageID: "msg_1",
+      source: "session",
+    });
+
+    expect(state.totalExecuted).toBe(1);
+    expect(state.countedChildIDs.ses_child).toBe(true);
+    expect(state.countedChildIDs["tool:part_1"]).toBeUndefined();
+  });
+
+  it("counts subtask fallback only when it has no matching counted session", () => {
+    const state = createEmptyState();
+
+    upsertRunningChild(state, {
+      id: "subtask:part_1",
+      title: "Fallback work",
+      parentID: "ses_parent",
+      messageID: "msg_1",
+      source: "subtask",
+    });
+    expect(state.totalExecuted).toBe(1);
+    expect(state.countedChildIDs["subtask:part_1"]).toBe(true);
+
+    upsertRunningChild(state, {
+      id: "ses_other",
+      title: "Other child",
+      parentID: "ses_parent",
+      messageID: "msg_2",
+      source: "session",
+    });
+    upsertRunningChild(state, {
+      id: "subtask:part_2",
+      title: "Already counted fallback",
+      parentID: "ses_parent",
+      messageID: "msg_2",
+      source: "subtask",
+      targetSessionID: "ses_other",
+    });
+
+    expect(state.totalExecuted).toBe(2);
+    expect(state.countedChildIDs.ses_other).toBe(true);
+    expect(state.countedChildIDs["subtask:part_2"]).toBeUndefined();
+  });
+
+  it("rekeys counted subtask fallback when the matching session appears", () => {
+    const state = createEmptyState();
+
+    upsertRunningChild(state, {
+      id: "subtask:part_1",
+      title: "Fallback work",
+      parentID: "ses_parent",
+      messageID: "msg_1",
+      source: "subtask",
+    });
+    expect(state.totalExecuted).toBe(1);
+    expect(state.countedChildIDs["subtask:part_1"]).toBe(true);
+
+    upsertRunningChild(state, {
+      id: "ses_child",
+      title: "Child work",
+      parentID: "ses_parent",
+      messageID: "msg_1",
+      source: "session",
+    });
+
+    expect(state.totalExecuted).toBe(1);
+    expect(state.countedChildIDs.ses_child).toBe(true);
+    expect(state.countedChildIDs["subtask:part_1"]).toBeUndefined();
+  });
+
+  it("reconciles counted subtask fallback when details add a target session", () => {
+    const state = createEmptyState();
+
+    upsertRunningChild(state, {
+      id: "subtask:part_1",
+      title: "Fallback work",
+      parentID: "ses_parent",
+      messageID: "msg_1",
+      source: "subtask",
+    });
+    expect(state.totalExecuted).toBe(1);
+
+    expect(
+      upsertChildDetails(state, "subtask:part_1", {
+        targetSessionID: "ses_child",
+      }),
+    ).toBe(true);
+
+    expect(state.totalExecuted).toBe(1);
+    expect(state.countedChildIDs.ses_child).toBe(true);
+    expect(state.countedChildIDs["subtask:part_1"]).toBeUndefined();
   });
 
   it("merges details, sanitizes tokens, and refreshes elapsed fields", () => {
@@ -116,8 +279,13 @@ describe("state", () => {
       updatedAt: "2026-04-30T09:30:00.000Z",
     });
 
-    expect(pruneTerminalChildren(state, new Date("2026-04-30T10:00:01.000Z"))).toBe(1);
-    expect(Object.keys(state.children).sort()).toEqual(["recentDone", "running"]);
+    expect(
+      pruneTerminalChildren(state, new Date("2026-04-30T10:00:01.000Z")),
+    ).toBe(1);
+    expect(Object.keys(state.children).sort()).toEqual([
+      "recentDone",
+      "running",
+    ]);
   });
 
   it("resolves env paths and preserve-state flag", async () => {
@@ -136,12 +304,50 @@ describe("state", () => {
     state.countedChildIDs.ses_child = true;
 
     await saveState(harness.statePath, state);
-    expect(await readRuntimeState(harness.statePath)).toMatchObject({ totalExecuted: 1 });
-    expect(await loadState(harness.statePath)).toMatchObject({ totalExecuted: 1 });
+    expect(await readRuntimeState(harness.statePath)).toMatchObject({
+      totalExecuted: 1,
+    });
+    expect(await loadState(harness.statePath)).toMatchObject({
+      totalExecuted: 1,
+    });
 
     const badPath = join(harness.dir, "nested", "bad.json");
     await mkdir(dirname(badPath), { recursive: true });
     await writeFile(badPath, "not json", "utf8");
-    expect(await loadState(badPath)).toMatchObject({ children: {}, totalExecuted: 0 });
+    expect(await loadState(badPath)).toMatchObject({
+      children: {},
+      totalExecuted: 0,
+    });
+  });
+
+  it("does not add newly loaded tool wrappers while preserving historical tool counts", async () => {
+    const harness = await createRuntimeHarness();
+    await writeFile(
+      harness.statePath,
+      JSON.stringify({
+        children: {
+          "tool:old": child({
+            id: "tool:old",
+            source: "tool",
+            targetSessionID: undefined,
+          }),
+          "tool:new": child({
+            id: "tool:new",
+            source: "tool",
+            targetSessionID: undefined,
+          }),
+        },
+        countedChildIDs: { "tool:old": true },
+        totalExecuted: 1,
+        updatedAt: "2026-04-30T10:00:00.000Z",
+      }),
+      "utf8",
+    );
+
+    const loaded = await loadState(harness.statePath);
+
+    expect(loaded.totalExecuted).toBe(1);
+    expect(loaded.countedChildIDs["tool:old"]).toBe(true);
+    expect(loaded.countedChildIDs["tool:new"]).toBeUndefined();
   });
 });

--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -350,4 +350,51 @@ describe("state", () => {
     expect(loaded.countedChildIDs["tool:old"]).toBe(true);
     expect(loaded.countedChildIDs["tool:new"]).toBeUndefined();
   });
+
+  it("normalizes counters after loading missing counted ids", async () => {
+    const harness = await createRuntimeHarness();
+    await writeFile(
+      harness.statePath,
+      JSON.stringify({
+        children: {
+          ses_child: child({ id: "ses_child", source: "session" }),
+        },
+        countedChildIDs: {},
+        totalExecuted: 0,
+        updatedAt: "2026-04-30T10:00:00.000Z",
+      }),
+      "utf8",
+    );
+
+    const loaded = await loadState(harness.statePath);
+
+    expect(loaded.countedChildIDs.ses_child).toBe(true);
+    expect(loaded.totalExecuted).toBe(1);
+  });
+
+  it("rekeys historical counted subtasks to their loaded target session ids", async () => {
+    const harness = await createRuntimeHarness();
+    await writeFile(
+      harness.statePath,
+      JSON.stringify({
+        children: {
+          "subtask:old": child({
+            id: "subtask:old",
+            source: "subtask",
+            targetSessionID: "ses_child",
+          }),
+        },
+        countedChildIDs: { "subtask:old": true },
+        totalExecuted: 1,
+        updatedAt: "2026-04-30T10:00:00.000Z",
+      }),
+      "utf8",
+    );
+
+    const loaded = await loadState(harness.statePath);
+
+    expect(loaded.totalExecuted).toBe(1);
+    expect(loaded.countedChildIDs.ses_child).toBe(true);
+    expect(loaded.countedChildIDs["subtask:old"]).toBeUndefined();
+  });
 });

--- a/src/state.ts
+++ b/src/state.ts
@@ -100,28 +100,160 @@ function isTechnicalDelegationTitle(value: string | undefined): boolean {
   return /^delegation:\s+/i.test(value.trim());
 }
 
-function isCountableWorkItem(child: Pick<ChildSessionState, "id" | "title"> &
-  Partial<Pick<ChildSessionState, "source">>): boolean {
-  if (child.source === "tool" || child.source === "subtask") return true;
-  if (child.source === "session" || child.id.startsWith("ses_")) {
-    return !isTechnicalDelegationTitle(child.title);
+type CountableChildInput = Pick<
+  ChildSessionState,
+  "id" | "title" | "parentID"
+> &
+  Partial<Pick<ChildSessionState, "messageID" | "source" | "targetSessionID">>;
+
+function isRealSessionChild(
+  child: Pick<ChildSessionState, "id"> &
+    Partial<Pick<ChildSessionState, "source">>,
+): boolean {
+  return child.source === "session" || child.id.startsWith("ses_");
+}
+
+function isSyntheticToolWrapper(
+  child: Partial<Pick<ChildSessionState, "source">>,
+): boolean {
+  return child.source === "tool";
+}
+
+function isSubtaskFallback(
+  child: Partial<Pick<ChildSessionState, "source">>,
+): boolean {
+  return child.source === "subtask";
+}
+
+function matchingCorrelation(
+  left: Pick<ChildSessionState, "parentID"> &
+    Partial<Pick<ChildSessionState, "messageID">>,
+  right: Pick<ChildSessionState, "parentID"> &
+    Partial<Pick<ChildSessionState, "messageID">>,
+): boolean {
+  return Boolean(
+    left.messageID &&
+      right.messageID &&
+      left.parentID === right.parentID &&
+      left.messageID === right.messageID,
+  );
+}
+
+function findMatchingCountedSessionID(
+  state: StatuslineState,
+  subtask: CountableChildInput,
+): string | undefined {
+  if (
+    subtask.targetSessionID &&
+    state.countedChildIDs[subtask.targetSessionID]
+  ) {
+    return subtask.targetSessionID;
   }
+
+  const matchingSessionIDs = Object.values(state.children)
+    .filter((child) => isRealSessionChild(child))
+    .filter((child) => state.countedChildIDs[child.id])
+    .filter((child) => matchingCorrelation(subtask, child))
+    .map((child) => child.id);
+
+  return matchingSessionIDs.length === 1 ? matchingSessionIDs[0] : undefined;
+}
+
+function findMatchingCountedSubtaskID(
+  state: StatuslineState,
+  session: CountableChildInput,
+): string | undefined {
+  const matchingTargetSubtasks = Object.values(state.children)
+    .filter((child) => isSubtaskFallback(child))
+    .filter((child) => state.countedChildIDs[child.id])
+    .filter((child) => child.targetSessionID === session.id)
+    .map((child) => child.id);
+
+  if (matchingTargetSubtasks.length === 1) return matchingTargetSubtasks[0];
+
+  const matchingCorrelatedSubtasks = Object.values(state.children)
+    .filter((child) => isSubtaskFallback(child))
+    .filter((child) => state.countedChildIDs[child.id])
+    .filter((child) => matchingCorrelation(session, child))
+    .map((child) => child.id);
+
+  return matchingCorrelatedSubtasks.length === 1
+    ? matchingCorrelatedSubtasks[0]
+    : undefined;
+}
+
+function rekeyCountedExecution(
+  state: StatuslineState,
+  fromID: string,
+  toID: string,
+): boolean {
+  if (fromID === toID) return false;
+  normalizeExecutionCounters(state);
+  if (!state.countedChildIDs[fromID]) return false;
+
+  const toAlreadyCounted = Boolean(state.countedChildIDs[toID]);
+  delete state.countedChildIDs[fromID];
+  if (!toAlreadyCounted) {
+    state.countedChildIDs[toID] = true;
+    return true;
+  }
+
+  state.totalExecuted = Math.max(
+    Object.keys(state.countedChildIDs).length,
+    (toNonNegativeInteger(state.totalExecuted) ?? 0) - 1,
+  );
   return true;
 }
 
-function countChildExecution(state: StatuslineState, child: Pick<ChildSessionState, "id" | "title"> &
-  Partial<Pick<ChildSessionState, "source">>): boolean {
-  if (!isCountableWorkItem(child)) return false;
+function resolveExecutionCountIdentity(
+  state: StatuslineState,
+  child: CountableChildInput,
+): string | undefined {
+  if (isSyntheticToolWrapper(child)) return undefined;
+
+  if (isRealSessionChild(child)) {
+    if (isTechnicalDelegationTitle(child.title)) return undefined;
+    const matchingSubtaskID = findMatchingCountedSubtaskID(state, child);
+    if (matchingSubtaskID) {
+      rekeyCountedExecution(state, matchingSubtaskID, child.id);
+      return undefined;
+    }
+    return child.id;
+  }
+
+  if (isSubtaskFallback(child)) {
+    if (findMatchingCountedSessionID(state, child)) return undefined;
+    return child.targetSessionID ?? child.id;
+  }
+
+  return child.id;
+}
+
+function countChildExecution(
+  state: StatuslineState,
+  child: CountableChildInput,
+): boolean {
   normalizeExecutionCounters(state);
-  if (state.countedChildIDs[child.id]) return false;
+  const countIdentity = resolveExecutionCountIdentity(state, child);
+  if (!countIdentity) return false;
+  if (state.countedChildIDs[countIdentity]) return false;
 
   const previousTotal = Math.max(
     toNonNegativeInteger(state.totalExecuted) ?? 0,
     Object.keys(state.countedChildIDs).length,
   );
-  state.countedChildIDs[child.id] = true;
+  state.countedChildIDs[countIdentity] = true;
   state.totalExecuted = previousTotal + 1;
   return true;
+}
+
+function reconcileSubtaskTargetCount(
+  state: StatuslineState,
+  child: Pick<ChildSessionState, "id"> &
+    Partial<Pick<ChildSessionState, "source" | "targetSessionID">>,
+): boolean {
+  if (!isSubtaskFallback(child) || !child.targetSessionID) return false;
+  return rekeyCountedExecution(state, child.id, child.targetSessionID);
 }
 
 function sanitizeTokens(input: unknown): ChildTokenState | undefined {
@@ -195,7 +327,10 @@ function sanitizeSummary(value: unknown, title: string): string | undefined {
 
 function sanitizeAgentName(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
-  const agentName = value.replace(/^\((.*)\)$/, "$1").replace(/\s+/g, " ").trim();
+  const agentName = value
+    .replace(/^\((.*)\)$/, "$1")
+    .replace(/\s+/g, " ")
+    .trim();
   return agentName || undefined;
 }
 
@@ -210,7 +345,9 @@ function resolveElapsedMs(child: ChildSessionState, nowMs: number): number {
 }
 
 function terminalReferenceMs(child: ChildSessionState): number {
-  const parsed = Date.parse(child.endedAt ?? child.updatedAt ?? child.startedAt);
+  const parsed = Date.parse(
+    child.endedAt ?? child.updatedAt ?? child.startedAt,
+  );
   return Number.isNaN(parsed) ? 0 : parsed;
 }
 
@@ -239,7 +376,9 @@ export function pruneTerminalChildren(
     return pruned;
   }
 
-  terminalChildren.sort((a, b) => b.referenceMs - a.referenceMs || a.id.localeCompare(b.id));
+  terminalChildren.sort(
+    (a, b) => b.referenceMs - a.referenceMs || a.id.localeCompare(b.id),
+  );
   for (const child of terminalChildren.slice(MAX_TERMINAL_CHILDREN)) {
     delete state.children[child.id];
     pruned += 1;
@@ -260,9 +399,13 @@ export function refreshDerivedFields(
   for (const [id, child] of Object.entries(state.children)) {
     const startedAt = safeTimestamp(child.startedAt, nowISO);
     const updatedAt = safeTimestamp(child.updatedAt, nowISO);
-    const endedAt = child.endedAt ? safeTimestamp(child.endedAt, updatedAt) : undefined;
+    const endedAt = child.endedAt
+      ? safeTimestamp(child.endedAt, updatedAt)
+      : undefined;
     const status =
-      child.status === "done" || child.status === "error" || child.status === "running"
+      child.status === "done" ||
+      child.status === "error" ||
+      child.status === "running"
         ? child.status
         : "running";
 
@@ -356,19 +499,10 @@ export async function loadState(statePath: string): Promise<StatuslineState> {
     }
 
     const children =
-      parsed.children && typeof parsed.children === "object" ? parsed.children : {};
-
+      parsed.children && typeof parsed.children === "object"
+        ? parsed.children
+        : {};
     const countedChildIDs = sanitizeCountedChildIDs(parsed.countedChildIDs);
-    for (const [id, child] of Object.entries(children)) {
-      const candidate = child as Partial<ChildSessionState>;
-      if (typeof candidate.title === "string" && isCountableWorkItem({
-        id,
-        title: candidate.title,
-        source: candidate.source,
-      })) {
-        countedChildIDs[id] = true;
-      }
-    }
 
     const state: StatuslineState = {
       children: children as Record<string, ChildSessionState>,
@@ -382,6 +516,29 @@ export async function loadState(statePath: string): Promise<StatuslineState> {
           ? parsed.updatedAt
           : new Date().toISOString(),
     };
+
+    for (const [id, child] of Object.entries(children)) {
+      const candidate = child as Partial<ChildSessionState>;
+      if (
+        typeof candidate.title !== "string" ||
+        typeof candidate.parentID !== "string"
+      ) {
+        continue;
+      }
+      const targetSessionID = sanitizeTargetSessionID(
+        candidate.targetSessionID,
+        id.startsWith("ses_") ? id : undefined,
+      );
+      const countIdentity = resolveExecutionCountIdentity(state, {
+        id,
+        title: candidate.title,
+        parentID: candidate.parentID,
+        messageID: candidate.messageID,
+        source: candidate.source,
+        targetSessionID,
+      });
+      if (countIdentity) state.countedChildIDs[countIdentity] = true;
+    }
 
     refreshDerivedFields(state);
     return state;
@@ -419,17 +576,21 @@ export function upsertRunningChild(
   const observedUpdatedAt = safeTimestamp(input.updatedAt, now);
   const observedStartedAt = safeTimestamp(input.startedAt, observedUpdatedAt);
   const existing = state.children[input.id];
+  const targetSessionID = sanitizeTargetSessionID(
+    input.targetSessionID ?? existing?.targetSessionID,
+    input.id.startsWith("ses_") ? input.id : undefined,
+  );
+  const source = input.source ?? existing?.source ?? "session";
   const counted = existing
     ? false
     : countChildExecution(state, {
         id: input.id,
         title: input.title,
-        source: input.source,
+        parentID: input.parentID,
+        messageID: input.messageID,
+        source,
+        targetSessionID,
       });
-  const targetSessionID = sanitizeTargetSessionID(
-    input.targetSessionID ?? existing?.targetSessionID,
-    input.id.startsWith("ses_") ? input.id : undefined,
-  );
   const shouldKeepCompletedTiming =
     existing?.status === "done" || existing?.status === "error";
   const next: ChildSessionState = {
@@ -441,7 +602,7 @@ export function upsertRunningChild(
     agentName: sanitizeAgentName(input.agentName) ?? existing?.agentName,
     parentID: input.parentID,
     messageID: input.messageID ?? existing?.messageID,
-    source: input.source ?? existing?.source ?? "session",
+    source,
     targetSessionID,
     status: shouldKeepCompletedTiming ? existing.status : "running",
     color: statusColor(shouldKeepCompletedTiming ? existing.status : "running"),
@@ -471,6 +632,7 @@ export function upsertRunningChild(
   }
 
   state.children[input.id] = next;
+  reconcileSubtaskTargetCount(state, next);
   state.updatedAt = observedUpdatedAt;
   return true;
 }
@@ -490,7 +652,7 @@ export function markChildStatus(
 
     const observedEndedAt = endedAt
       ? safeTimestamp(endedAt, now)
-      : child.endedAt ?? now;
+      : (child.endedAt ?? now);
 
     if (
       child.status === status &&
@@ -544,7 +706,8 @@ export function upsertChildDetails(
   const nextSummary =
     sanitizeSummary(input.summary, nextTitle) ??
     sanitizeSummary(existing.summary, nextTitle);
-  const nextAgentName = sanitizeAgentName(input.agentName) ?? existing.agentName;
+  const nextAgentName =
+    sanitizeAgentName(input.agentName) ?? existing.agentName;
   const mergedTokens = mergeTokens(existing.tokens, input.tokens);
   const nextTargetSessionID = sanitizeTargetSessionID(
     input.targetSessionID ?? existing.targetSessionID,
@@ -562,7 +725,7 @@ export function upsertChildDetails(
 
   const now = new Date().toISOString();
   const observedUpdatedAt = safeTimestamp(input.updatedAt, now);
-  state.children[childID] = {
+  const next: ChildSessionState = {
     ...existing,
     title: nextTitle,
     summary: nextSummary,
@@ -571,6 +734,8 @@ export function upsertChildDetails(
     targetSessionID: nextTargetSessionID,
     updatedAt: observedUpdatedAt,
   };
+  state.children[childID] = next;
+  reconcileSubtaskTargetCount(state, next);
   state.updatedAt = observedUpdatedAt;
   return true;
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -537,9 +537,14 @@ export async function loadState(statePath: string): Promise<StatuslineState> {
         source: candidate.source,
         targetSessionID,
       });
-      if (countIdentity) state.countedChildIDs[countIdentity] = true;
+      if (countIdentity && countIdentity !== id && state.countedChildIDs[id]) {
+        rekeyCountedExecution(state, id, countIdentity);
+      } else if (countIdentity) {
+        state.countedChildIDs[countIdentity] = true;
+      }
     }
 
+    normalizeExecutionCounters(state);
     refreshDerivedFields(state);
     return state;
   } catch {

--- a/src/state.ts
+++ b/src/state.ts
@@ -529,6 +529,9 @@ export async function loadState(statePath: string): Promise<StatuslineState> {
         candidate.targetSessionID,
         id.startsWith("ses_") ? id : undefined,
       );
+      if (candidate.source === "subtask" && targetSessionID && state.countedChildIDs[id]) {
+        rekeyCountedExecution(state, id, targetSessionID);
+      }
       const countIdentity = resolveExecutionCountIdentity(state, {
         id,
         title: candidate.title,


### PR DESCRIPTION
Closes #50

## Summary

- Treat synthetic `source: "tool"` wrappers as status evidence, not executed subagents.
- Keep real `source: "session"` rows counted exactly once.
- Add deterministic subtask fallback rekey/merge behavior so fallback rows do not inflate totals when the real session appears.

## Chain Context

Stacked PRs to main:

```text
main
└── 📍 PR 1: state counting semantics (this PR)
    └── PR 2: sync task event/render collapse follow-up
```

Start state: current `main` counts synthetic wrappers/subtasks too eagerly.
End state: state counters represent unique subagent executions without tool-wrapper inflation.
Follow-up: PR 2 handles live synchronous OpenCode `task` correlation/render duplication.
Out of scope: committing local SDD artifacts in this PR.

## Changes

| File | Change |
|------|--------|
| `src/state.ts` | Adds source-aware execution count identity, subtask/session rekeying, and load-state compatibility. |
| `src/state.test.ts` | Adds regression tests for uncounted tool wrappers, session exactly-once counting, subtask fallback/rekeying, and load-state behavior. |

## Validation

- [x] `pnpm test`
- [x] `pnpm typecheck`
- [x] `pnpm build`

## Checklist

- [x] I used a Conventional Commit title (e.g. `fix: ...`, `feat: ...`, `docs: ...`)
- [x] I linked related issue(s), or explained why none are needed
- [x] I did not include secrets, credentials, or private data
- [x] I called out any security-sensitive behavior changes
- [x] I updated docs when behavior or usage changed
