### PR TITLE
fix(events): collapse synchronous task duplicates

### DIFF
--- a/src/events.test.ts
+++ b/src/events.test.ts
@@ -119,33 +119,33 @@ describe("events", () => {
     });
   });
 
-  it.each(["busy", "retry"])(
-    "keeps a running child active for session.status %s",
-    (status) => {
-      const state = createEmptyState();
-      applySubagentEvent(state, {
-        type: "session.created",
-        properties: {
-          info: {
-            id: "ses_child_running",
-            parentID: "ses_parent",
-            title: "Child running",
-          },
+  it.each([
+    "busy",
+    "retry",
+  ])("keeps a running child active for session.status %s", (status) => {
+    const state = createEmptyState();
+    applySubagentEvent(state, {
+      type: "session.created",
+      properties: {
+        info: {
+          id: "ses_child_running",
+          parentID: "ses_parent",
+          title: "Child running",
         },
-      });
+      },
+    });
 
-      applySubagentEvent(state, {
-        type: "session.status",
-        properties: {
-          sessionID: "ses_child_running",
-          status,
-        },
-      });
+    applySubagentEvent(state, {
+      type: "session.status",
+      properties: {
+        sessionID: "ses_child_running",
+        status,
+      },
+    });
 
-      expect(state.children.ses_child_running?.status).toBe("running");
-      expect(state.children.ses_child_running?.endedAt).toBeUndefined();
-    },
-  );
+    expect(state.children.ses_child_running?.status).toBe("running");
+    expect(state.children.ses_child_running?.endedAt).toBeUndefined();
+  });
 
   it("maps session.status terminal errors to error", () => {
     const state = createEmptyState();
@@ -222,9 +222,86 @@ describe("extractTaskToolEvidence", () => {
       endedAt: "2026-04-30T12:05:00.000Z",
     });
   });
+
+  it("parses task session ids from output variants", () => {
+    expect(
+      extractTaskToolEvidence({
+        type: "message.part.updated",
+        properties: {
+          part: {
+            type: "tool",
+            tool: "task",
+            state: {
+              status: "completed",
+              output: "Task ID: ses_child_3",
+            },
+          },
+        },
+      })?.targetSessionID,
+    ).toBe("ses_child_3");
+
+    expect(
+      extractTaskToolEvidence({
+        type: "message.part.updated",
+        properties: {
+          part: {
+            type: "tool",
+            tool: "task",
+            state: {
+              status: "completed",
+              output: "finished session ses_child_4",
+            },
+          },
+        },
+      })?.targetSessionID,
+    ).toBe("ses_child_4");
+  });
 });
 
 describe("task tool to subtask mapping", () => {
+  it("backfills a synchronous task tool wrapper when its session appears later", () => {
+    const state = createEmptyState();
+
+    applySubagentEvent(state, {
+      type: "message.part.updated",
+      properties: {
+        sessionID: "ses_parent",
+        part: {
+          type: "tool",
+          tool: "task",
+          id: "tool_sync",
+          sessionID: "ses_parent",
+          messageID: "msg_sync",
+          state: {
+            status: "running",
+            input: { description: "Run sync task" },
+          },
+        },
+      },
+    });
+
+    expect(state.children["tool:tool_sync"]?.targetSessionID).toBeUndefined();
+    expect(state.totalExecuted).toBe(0);
+
+    applySubagentEvent(state, {
+      type: "session.created",
+      properties: {
+        info: {
+          id: "ses_sync_child",
+          parentID: "ses_parent",
+          title: "Child session with unrelated title",
+        },
+      },
+    });
+
+    expect(state.children["tool:tool_sync"]?.targetSessionID).toBe(
+      "ses_sync_child",
+    );
+    expect(state.totalExecuted).toBe(1);
+    expect(state.countedChildIDs.ses_sync_child).toBe(true);
+    expect(state.countedChildIDs["tool:tool_sync"]).toBeUndefined();
+  });
+
   it("maps completed task tool evidence to matching subtask row", () => {
     const state = createEmptyState();
     upsertSubtask(state, {
@@ -255,8 +332,12 @@ describe("task tool to subtask mapping", () => {
     });
 
     expect(state.children["subtask:sub_1"]?.status).toBe("done");
-    expect(state.children["subtask:sub_1"]?.targetSessionID).toBe("ses_child_1");
-    expect(state.children["subtask:sub_1"]?.endedAt).toBe("2026-04-30T12:00:00.000Z");
+    expect(state.children["subtask:sub_1"]?.targetSessionID).toBe(
+      "ses_child_1",
+    );
+    expect(state.children["subtask:sub_1"]?.endedAt).toBe(
+      "2026-04-30T12:00:00.000Z",
+    );
   });
 
   it("fails closed for ambiguous mapping", () => {
@@ -367,14 +448,14 @@ describe("task tool to subtask mapping", () => {
       },
     });
 
-    expect(state.children["subtask:prt_ddea56110001RtlmRJFV99PmiU"]?.status).toBe(
-      "done",
-    );
+    expect(
+      state.children["subtask:prt_ddea56110001RtlmRJFV99PmiU"]?.status,
+    ).toBe("done");
     expect(
       state.children["subtask:prt_ddea56110001RtlmRJFV99PmiU"]?.targetSessionID,
     ).toBe("ses_2215a9eceffelCOOb8v66cT2v0");
-    expect(state.children["subtask:prt_ddea56110001RtlmRJFV99PmiU"]?.endedAt).toBe(
-      "2026-04-30T12:20:00.000Z",
-    );
+    expect(
+      state.children["subtask:prt_ddea56110001RtlmRJFV99PmiU"]?.endedAt,
+    ).toBe("2026-04-30T12:20:00.000Z");
   });
 });

--- a/src/events.test.ts
+++ b/src/events.test.ts
@@ -244,17 +244,37 @@ describe("extractTaskToolEvidence", () => {
       extractTaskToolEvidence({
         type: "message.part.updated",
         properties: {
+          sessionID: "ses_parent",
           part: {
             type: "tool",
             tool: "task",
+            sessionID: "ses_parent",
             state: {
               status: "completed",
-              output: "finished session ses_child_4",
+              output: "parent ses_parent finished child ses_child_4",
             },
           },
         },
       })?.targetSessionID,
     ).toBe("ses_child_4");
+  });
+
+  it("does not infer a task target from ambiguous output session ids", () => {
+    expect(
+      extractTaskToolEvidence({
+        type: "message.part.updated",
+        properties: {
+          part: {
+            type: "tool",
+            tool: "task",
+            state: {
+              status: "completed",
+              output: "first ses_child_1 then ses_child_2",
+            },
+          },
+        },
+      })?.targetSessionID,
+    ).toBeUndefined();
   });
 });
 
@@ -300,6 +320,52 @@ describe("task tool to subtask mapping", () => {
     expect(state.totalExecuted).toBe(1);
     expect(state.countedChildIDs.ses_sync_child).toBe(true);
     expect(state.countedChildIDs["tool:tool_sync"]).toBeUndefined();
+  });
+
+  it("does not backfill a targetless task wrapper when another session sibling already exists", () => {
+    const state = createEmptyState();
+
+    applySubagentEvent(state, {
+      type: "session.created",
+      properties: {
+        info: {
+          id: "ses_existing_child",
+          parentID: "ses_parent",
+          title: "Existing child",
+        },
+      },
+    });
+    applySubagentEvent(state, {
+      type: "message.part.updated",
+      properties: {
+        sessionID: "ses_parent",
+        part: {
+          type: "tool",
+          tool: "task",
+          id: "tool_sync",
+          sessionID: "ses_parent",
+          state: {
+            status: "running",
+            input: { description: "Run sync task" },
+          },
+        },
+      },
+    });
+    applySubagentEvent(state, {
+      type: "session.created",
+      properties: {
+        info: {
+          id: "ses_later_child",
+          parentID: "ses_parent",
+          title: "Later child",
+        },
+      },
+    });
+
+    expect(state.children["tool:tool_sync"]?.targetSessionID).toBeUndefined();
+    expect(state.totalExecuted).toBe(2);
+    expect(state.countedChildIDs.ses_existing_child).toBe(true);
+    expect(state.countedChildIDs.ses_later_child).toBe(true);
   });
 
   it("maps completed task tool evidence to matching subtask row", () => {

--- a/src/events.ts
+++ b/src/events.ts
@@ -251,10 +251,15 @@ function extractPartTargetSessionCandidates(event: EventLike): string[] {
   return [...candidates];
 }
 
-function parseTaskSessionIDFromOutput(value: unknown): string | undefined {
+function parseTaskSessionIDFromOutput(
+  value: unknown,
+  parentSessionID?: string,
+): string | undefined {
   if (typeof value !== "string") return undefined;
-  const match = value.match(/\b(?:task_id\s*:\s*)?(ses_[a-zA-Z0-9_-]+)\b/i);
-  return match?.[1];
+  const matches = [...value.matchAll(/\b(?:task_id\s*:\s*)?(ses_[a-zA-Z0-9_-]+)\b/gi)];
+  const candidates = new Set(matches.map((match) => match[1]));
+  if (parentSessionID) candidates.delete(parentSessionID);
+  return candidates.size === 1 ? [...candidates][0] : undefined;
 }
 
 function backfillSyntheticTargetsForSession(
@@ -278,9 +283,18 @@ function backfillSyntheticTargetsForSession(
         (child) => child.messageID === session.messageID,
       )
     : [];
+  const existingSessionSiblings = Object.values(state.children).filter(
+    (child) =>
+      child.id !== session.id &&
+      (child.source === "session" || child.id.startsWith("ses_")) &&
+      child.parentID === session.parentID,
+  );
   const candidates =
     messageMatches.length > 0 ? messageMatches : targetlessSynthetic;
   if (candidates.length !== 1) return false;
+  if (messageMatches.length === 0 && existingSessionSiblings.length > 0) {
+    return false;
+  }
 
   const synthetic = candidates[0];
   const targetSessionID = resolveSyntheticTargetSessionID(
@@ -320,7 +334,11 @@ export function extractTaskToolEvidence(
 
   const metadata = isRecord(state.metadata) ? state.metadata : undefined;
   const targetFromMetadata = asString(metadata?.sessionId);
-  const targetFromOutput = parseTaskSessionIDFromOutput(state.output);
+  const parentSessionID = asString(part.sessionID) ?? extractSessionID(event);
+  const targetFromOutput = parseTaskSessionIDFromOutput(
+    state.output,
+    parentSessionID,
+  );
   const targetCandidates = extractPartTargetSessionCandidates(event);
   const targetSessionID =
     targetFromMetadata ??

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,6 +1,10 @@
 import type { ChildTokenState, StatuslineState } from "./state.js";
 import { deriveOpenCodeSessionStatus } from "./reconcile.js";
-import { markChildStatus, upsertChildDetails, upsertRunningChild } from "./state.js";
+import {
+  markChildStatus,
+  upsertChildDetails,
+  upsertRunningChild,
+} from "./state.js";
 
 export type EventLike = {
   type?: unknown;
@@ -81,7 +85,10 @@ function conciseText(value: unknown): string | undefined {
   return text.length > 180 ? `${text.slice(0, 179)}…` : text;
 }
 
-function sameDisplayText(a: string | undefined, b: string | undefined): boolean {
+function sameDisplayText(
+  a: string | undefined,
+  b: string | undefined,
+): boolean {
   if (!a || !b) return false;
   return (
     a.replace(/\s+/g, " ").trim().toLowerCase() ===
@@ -171,7 +178,11 @@ function isSessionID(value: unknown): value is string {
   return typeof value === "string" && value.startsWith("ses_");
 }
 
-function collectSessionIDs(input: unknown, target: Set<string>, depth = 0): void {
+function collectSessionIDs(
+  input: unknown,
+  target: Set<string>,
+  depth = 0,
+): void {
   if (depth > 4 || !input) return;
 
   if (isSessionID(input)) {
@@ -214,7 +225,8 @@ function resolveSyntheticTargetSessionID(
   }
 
   const byParent = Object.values(state.children).filter(
-    (child) => child.id.startsWith("ses_") && child.parentID === synthetic.parentID,
+    (child) =>
+      child.id.startsWith("ses_") && child.parentID === synthetic.parentID,
   );
   if (byParent.length === 1) {
     candidates.add(byParent[0].id);
@@ -225,7 +237,9 @@ function resolveSyntheticTargetSessionID(
 }
 
 function extractPartTargetSessionCandidates(event: EventLike): string[] {
-  const part = isRecord(event.properties?.part) ? event.properties.part : undefined;
+  const part = isRecord(event.properties?.part)
+    ? event.properties.part
+    : undefined;
   if (!part) return [];
 
   const candidates = new Set<string>();
@@ -239,11 +253,56 @@ function extractPartTargetSessionCandidates(event: EventLike): string[] {
 
 function parseTaskSessionIDFromOutput(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
-  const match = value.match(/\btask_id\s*:\s*(ses_[a-zA-Z0-9_-]+)/);
+  const match = value.match(/\b(?:task_id\s*:\s*)?(ses_[a-zA-Z0-9_-]+)\b/i);
   return match?.[1];
 }
 
-export function extractTaskToolEvidence(event: EventLike): TaskToolEvidence | null {
+function backfillSyntheticTargetsForSession(
+  state: StatuslineState,
+  session: {
+    id: string;
+    parentID: string;
+    messageID?: string;
+    updatedAt?: string;
+  },
+): boolean {
+  const targetlessSynthetic = Object.values(state.children).filter(
+    (child) =>
+      (child.source === "tool" || child.source === "subtask") &&
+      !child.targetSessionID &&
+      child.parentID === session.parentID,
+  );
+
+  const messageMatches = session.messageID
+    ? targetlessSynthetic.filter(
+        (child) => child.messageID === session.messageID,
+      )
+    : [];
+  const candidates =
+    messageMatches.length > 0 ? messageMatches : targetlessSynthetic;
+  if (candidates.length !== 1) return false;
+
+  const synthetic = candidates[0];
+  const targetSessionID = resolveSyntheticTargetSessionID(
+    state,
+    {
+      id: synthetic.id,
+      parentID: synthetic.parentID,
+      messageID: synthetic.messageID,
+    },
+    [session.id],
+  );
+  if (targetSessionID !== session.id) return false;
+
+  return upsertChildDetails(state, synthetic.id, {
+    targetSessionID,
+    updatedAt: session.updatedAt,
+  });
+}
+
+export function extractTaskToolEvidence(
+  event: EventLike,
+): TaskToolEvidence | null {
   const part = event.properties?.part;
   if (!isRecord(part) || part.type !== "tool") return null;
   if (asString(part.tool) !== "task") return null;
@@ -302,9 +361,12 @@ function mapTaskToolToSubtaskID(
     (child) => child.messageID === task.messageID,
   );
   const legacyCandidates = task.parentMessageID
-    ? runningSubtasks.filter((child) => child.messageID === task.parentMessageID)
+    ? runningSubtasks.filter(
+        (child) => child.messageID === task.parentMessageID,
+      )
     : [];
-  const candidates = primaryCandidates.length > 0 ? primaryCandidates : legacyCandidates;
+  const candidates =
+    primaryCandidates.length > 0 ? primaryCandidates : legacyCandidates;
   if (candidates.length === 0) return undefined;
 
   if (task.targetSessionID) {
@@ -325,7 +387,9 @@ function mapTaskToolToSubtaskID(
   if (bySummary.length === 1) return bySummary[0].id;
 
   const byAgent = task.agentName
-    ? candidates.filter((child) => sameDisplayText(child.agentName, task.agentName))
+    ? candidates.filter((child) =>
+        sameDisplayText(child.agentName, task.agentName),
+      )
     : [];
   if (byAgent.length === 1) return byAgent[0].id;
 
@@ -359,11 +423,18 @@ function toIsoTimestamp(value: unknown): string | undefined {
   return undefined;
 }
 
-function extractEventTimestamp(event: EventLike, keys: string[]): string | undefined {
-  const part = isRecord(event.properties?.part) ? event.properties?.part : undefined;
+function extractEventTimestamp(
+  event: EventLike,
+  keys: string[],
+): string | undefined {
+  const part = isRecord(event.properties?.part)
+    ? event.properties?.part
+    : undefined;
   const state = isRecord(part?.state) ? part?.state : undefined;
   const sources = [
-    isRecord(event.properties?.info?.time) ? event.properties?.info?.time : undefined,
+    isRecord(event.properties?.info?.time)
+      ? event.properties?.info?.time
+      : undefined,
     isRecord(part?.time) ? part?.time : undefined,
     isRecord(part?.timestamps) ? part?.timestamps : undefined,
     isRecord(state?.time) ? state?.time : undefined,
@@ -412,7 +483,8 @@ function extractSubtaskChild(event: EventLike): SubtaskChild | null {
     extractEventTimestamp(event, ["updated", "created", "started", "start"]) ??
     startedAt;
   const targetCandidates = extractPartTargetSessionCandidates(event);
-  const targetSessionID = targetCandidates.length === 1 ? targetCandidates[0] : undefined;
+  const targetSessionID =
+    targetCandidates.length === 1 ? targetCandidates[0] : undefined;
 
   return {
     id: `subtask:${partID}`,
@@ -471,8 +543,13 @@ function extractToolChild(event: EventLike): ToolChild | null {
     "updated",
   ]);
   const updatedAt =
-    extractEventTimestamp(event, ["updated", "completed", "created", "started", "start"]) ??
-    startedAt;
+    extractEventTimestamp(event, [
+      "updated",
+      "completed",
+      "created",
+      "started",
+      "start",
+    ]) ?? startedAt;
   const endedAt =
     status === "done" || status === "error"
       ? extractEventTimestamp(event, ["completed", "end", "ended", "updated"])
@@ -585,7 +662,9 @@ export function extractChildDetails(event: EventLike): {
     }
   }
 
-  const part = isRecord(event.properties?.part) ? event.properties.part : undefined;
+  const part = isRecord(event.properties?.part)
+    ? event.properties.part
+    : undefined;
   const partState = isRecord(part?.state) ? part.state : undefined;
   const partInput = isRecord(partState?.input) ? partState.input : undefined;
   details.agentName =
@@ -606,7 +685,11 @@ export function extractChildDetails(event: EventLike): {
   if (isTechnicalDelegationTitle(details.title)) {
     const replacementTitle =
       asString(partInput?.description) ??
-      firstUsefulTitle([partInput?.prompt, part?.description, partState?.description]);
+      firstUsefulTitle([
+        partInput?.prompt,
+        part?.description,
+        partState?.description,
+      ]);
     if (replacementTitle) {
       details.title = replacementTitle;
     }
@@ -671,7 +754,10 @@ export function extractChildDetails(event: EventLike): {
   return details;
 }
 
-export function applySubagentEvent(state: StatuslineState, event: unknown): boolean {
+export function applySubagentEvent(
+  state: StatuslineState,
+  event: unknown,
+): boolean {
   const e = (event ?? {}) as EventLike;
   const type = asString(e.type);
   if (!type) return false;
@@ -686,6 +772,12 @@ export function applySubagentEvent(state: StatuslineState, event: unknown): bool
         targetSessionID: child.id,
       });
       changed = upsertChildDetails(state, child.id, details) || changed;
+      changed =
+        backfillSyntheticTargetsForSession(state, {
+          id: child.id,
+          parentID: child.parentID,
+          updatedAt: child.updatedAt,
+        }) || changed;
       return changed;
     }
     return false;
@@ -694,7 +786,12 @@ export function applySubagentEvent(state: StatuslineState, event: unknown): bool
   if (type === "session.idle") {
     const childID = extractSessionID(e);
     if (!childID) return false;
-    const endedAt = extractEventTimestamp(e, ["completed", "end", "ended", "updated"]);
+    const endedAt = extractEventTimestamp(e, [
+      "completed",
+      "end",
+      "ended",
+      "updated",
+    ]);
     const details = extractChildDetails(e);
     let changed = markChildStatus(state, childID, "done", endedAt);
     changed = upsertChildDetails(state, childID, details) || changed;
@@ -704,7 +801,12 @@ export function applySubagentEvent(state: StatuslineState, event: unknown): bool
   if (type === "session.error") {
     const childID = extractSessionID(e);
     if (!childID) return false;
-    const endedAt = extractEventTimestamp(e, ["completed", "end", "ended", "updated"]);
+    const endedAt = extractEventTimestamp(e, [
+      "completed",
+      "end",
+      "ended",
+      "updated",
+    ]);
     const details = extractChildDetails(e);
     let changed = markChildStatus(state, childID, "error", endedAt);
     changed = upsertChildDetails(state, childID, details) || changed;
@@ -730,7 +832,9 @@ export function applySubagentEvent(state: StatuslineState, event: unknown): bool
         : undefined;
     const details = extractChildDetails(e);
     let changed =
-      status === "running" ? false : markChildStatus(state, childID, status, endedAt);
+      status === "running"
+        ? false
+        : markChildStatus(state, childID, status, endedAt);
     changed = upsertChildDetails(state, childID, details) || changed;
     return changed;
   }
@@ -780,10 +884,18 @@ export function applySubagentEvent(state: StatuslineState, event: unknown): bool
       changed = childChanged || changed;
       if (tool.status === "done" || tool.status === "error") {
         changed =
-          markChildStatus(state, tool.id, tool.status, tool.endedAt ?? tool.updatedAt) ||
-          changed;
+          markChildStatus(
+            state,
+            tool.id,
+            tool.status,
+            tool.endedAt ?? tool.updatedAt,
+          ) || changed;
 
-        if (asString((e.properties?.part as Record<string, unknown> | undefined)?.tool) === "task") {
+        if (
+          asString(
+            (e.properties?.part as Record<string, unknown> | undefined)?.tool,
+          ) === "task"
+        ) {
           const subtaskID = mapTaskToolToSubtaskID(state, {
             parentID: tool.parentID,
             messageID: tool.messageID,
@@ -802,8 +914,12 @@ export function applySubagentEvent(state: StatuslineState, event: unknown): bool
                 }) || changed;
             }
             changed =
-              markChildStatus(state, subtaskID, tool.status, tool.endedAt ?? tool.updatedAt) ||
-              changed;
+              markChildStatus(
+                state,
+                subtaskID,
+                tool.status,
+                tool.endedAt ?? tool.updatedAt,
+              ) || changed;
           }
         }
       }

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -81,7 +81,7 @@ describe("render", () => {
       }),
       child({
         id: "ses_sync_child",
-        title: "Child session with unrelated title",
+        title: "Run task cleanup",
         source: "session",
         targetSessionID: "ses_sync_child",
         messageID: undefined,

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -70,7 +70,7 @@ describe("render", () => {
     ]);
   });
 
-  it("collapses a targetless synchronous task wrapper with the only session sibling", () => {
+  it("does not collapse a targetless generic task wrapper without correlation", () => {
     const children: ChildSessionState[] = [
       child({
         id: "tool:sync-task",
@@ -89,13 +89,10 @@ describe("render", () => {
       }),
     ];
 
-    const collapsed = collapseSubagentWorkItems(children);
-
-    expect(collapsed.map((item) => item.id)).toEqual(["tool:sync-task"]);
-    expect(collapsed[0]).toMatchObject({
-      status: "running",
-      targetSessionID: "ses_sync_child",
-    });
+    expect(collapseSubagentWorkItems(children).map((item) => item.id)).toEqual([
+      "tool:sync-task",
+      "ses_sync_child",
+    ]);
   });
 
   it("keeps one grouped row and avoids duplicate wrappers", () => {

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -70,6 +70,34 @@ describe("render", () => {
     ]);
   });
 
+  it("collapses a targetless synchronous task wrapper with the only session sibling", () => {
+    const children: ChildSessionState[] = [
+      child({
+        id: "tool:sync-task",
+        title: "task",
+        source: "tool",
+        targetSessionID: undefined,
+        messageID: "msg_sync",
+      }),
+      child({
+        id: "ses_sync_child",
+        title: "Child session with unrelated title",
+        source: "session",
+        targetSessionID: "ses_sync_child",
+        messageID: undefined,
+        status: "running",
+      }),
+    ];
+
+    const collapsed = collapseSubagentWorkItems(children);
+
+    expect(collapsed.map((item) => item.id)).toEqual(["tool:sync-task"]);
+    expect(collapsed[0]).toMatchObject({
+      status: "running",
+      targetSessionID: "ses_sync_child",
+    });
+  });
+
   it("keeps one grouped row and avoids duplicate wrappers", () => {
     const children: ChildSessionState[] = [
       child({
@@ -124,7 +152,9 @@ describe("render", () => {
     });
 
     expect(
-      visibleSubagentWorkItems([visibleDone, hiddenDone], now).map((item) => item.id),
+      visibleSubagentWorkItems([visibleDone, hiddenDone], now).map(
+        (item) => item.id,
+      ),
     ).toEqual(["done_recent"]);
   });
 
@@ -166,7 +196,9 @@ describe("render", () => {
       "subtask:active",
       "subtask:active-done",
     ]);
-    expect(visible.some((item) => item.id === "subtask:historical")).toBe(false);
+    expect(visible.some((item) => item.id === "subtask:historical")).toBe(
+      false,
+    );
   });
 
   it("sorts ties by id for stable priority", () => {
@@ -185,14 +217,21 @@ describe("render", () => {
           status: "running",
           color: "yellow",
         }),
-        error: child({ id: "error", title: "Fix bug", status: "error", color: "red" }),
+        error: child({
+          id: "error",
+          title: "Fix bug",
+          status: "error",
+          color: "red",
+        }),
       },
       countedChildIDs: { running: true, error: true },
       totalExecuted: 2,
       updatedAt: "2026-04-30T10:00:00.000Z",
     };
 
-    expect(renderStatusLine(state)).toContain("↳ 1 running · 0 done · 1 error · Σ 2 total");
+    expect(renderStatusLine(state)).toContain(
+      "↳ 1 running · 0 done · 1 error · Σ 2 total",
+    );
     expect(renderStatusLine(state)).toContain("Run tests 01:01");
     expect(renderStatusLine(state)).not.toContain("\u001B[");
   });

--- a/src/render.ts
+++ b/src/render.ts
@@ -275,12 +275,7 @@ export function collapseSubagentWorkItems(
     const sessionCandidates =
       sessionCandidatesByParentID.get(synthetic.parentID) ?? [];
     for (const candidate of sessionCandidates) {
-      const isOnlySessionSibling =
-        isGenericToolWrapper(synthetic) && sessionCandidates.length === 1;
-      if (
-        !isOnlySessionSibling &&
-        !sessionMatchesSynthetic(candidate, synthetic)
-      ) {
+      if (!sessionMatchesSynthetic(candidate, synthetic)) {
         continue;
       }
       bestSession = betterPriority(bestSession, candidate);

--- a/src/render.ts
+++ b/src/render.ts
@@ -191,6 +191,7 @@ function sessionMatchesSynthetic(
   ) {
     return true;
   }
+  if (isGenericToolWrapper(synthetic)) return false;
   return (
     sameAgentName(session.agentName, synthetic.agentName) &&
     relatedWorkItemTitles(session.title, synthetic.title)

--- a/src/render.ts
+++ b/src/render.ts
@@ -81,7 +81,9 @@ function formatCompactPercentUsed(percent: number): string {
   return `${Math.max(0, rounded)}%`;
 }
 
-export function formatContextDetails(child: ChildSessionState): string | undefined {
+export function formatContextDetails(
+  child: ChildSessionState,
+): string | undefined {
   const total = resolveTokenTotal(child);
   const percent = child.tokens?.contextPercent;
 
@@ -177,7 +179,8 @@ function sessionMatchesSynthetic(
   session: ChildSessionState,
   synthetic: ChildSessionState,
 ): boolean {
-  if (session.source !== "session" && !session.id.startsWith("ses_")) return false;
+  if (session.source !== "session" && !session.id.startsWith("ses_"))
+    return false;
   if (session.parentID !== synthetic.parentID) return false;
   if (synthetic.targetSessionID === session.id) return true;
   if (session.targetSessionID === synthetic.id) return true;
@@ -269,8 +272,17 @@ export function collapseSubagentWorkItems(
 
   for (const synthetic of syntheticChildren) {
     let bestSession: ChildSessionState | undefined;
-    for (const candidate of sessionCandidatesByParentID.get(synthetic.parentID) ?? []) {
-      if (!sessionMatchesSynthetic(candidate, synthetic)) continue;
+    const sessionCandidates =
+      sessionCandidatesByParentID.get(synthetic.parentID) ?? [];
+    for (const candidate of sessionCandidates) {
+      const isOnlySessionSibling =
+        isGenericToolWrapper(synthetic) && sessionCandidates.length === 1;
+      if (
+        !isOnlySessionSibling &&
+        !sessionMatchesSynthetic(candidate, synthetic)
+      ) {
+        continue;
+      }
       bestSession = betterPriority(bestSession, candidate);
       if (candidate.source === "session") {
         hiddenMatchedSessionIDs.add(candidate.id);
@@ -305,7 +317,9 @@ export function collapseSubagentWorkItems(
         return !(
           hiddenTargetSessionIDs.has(child.id) ||
           (child.messageID &&
-            hiddenMessageKeys.has(messageKey(child.parentID, child.messageID))) ||
+            hiddenMessageKeys.has(
+              messageKey(child.parentID, child.messageID),
+            )) ||
           hiddenMatchedSessionIDs.has(child.id)
         );
       }
@@ -313,7 +327,9 @@ export function collapseSubagentWorkItems(
       if (child.source !== "tool") return true;
       return !hiddenSyntheticToolIDs.has(child.id);
     })
-    .map((child) => mergeSyntheticWithSession(child, sessionBySyntheticID.get(child.id)));
+    .map((child) =>
+      mergeSyntheticWithSession(child, sessionBySyntheticID.get(child.id)),
+    );
 }
 
 export function isVisibleWorkItem(
@@ -350,7 +366,9 @@ export function visibleSubagentWorkItems(
 }
 
 export function renderStatusLine(state: StatuslineState): string {
-  const children = visibleSubagentWorkItems(Object.values(state.children)).sort(byPriority);
+  const children = visibleSubagentWorkItems(Object.values(state.children)).sort(
+    byPriority,
+  );
   const running = children.filter((c) => c.status === "running").length;
   const done = children.filter((c) => c.status === "done").length;
   const error = children.filter((c) => c.status === "error").length;

--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -397,4 +397,30 @@ describe("state", () => {
     expect(loaded.countedChildIDs.ses_child).toBe(true);
     expect(loaded.countedChildIDs["subtask:old"]).toBeUndefined();
   });
+
+  it("deduplicates historical subtask and target ids that were both counted", async () => {
+    const harness = await createRuntimeHarness();
+    await writeFile(
+      harness.statePath,
+      JSON.stringify({
+        children: {
+          "subtask:old": child({
+            id: "subtask:old",
+            source: "subtask",
+            targetSessionID: "ses_child",
+          }),
+        },
+        countedChildIDs: { "subtask:old": true, ses_child: true },
+        totalExecuted: 2,
+        updatedAt: "2026-04-30T10:00:00.000Z",
+      }),
+      "utf8",
+    );
+
+    const loaded = await loadState(harness.statePath);
+
+    expect(loaded.totalExecuted).toBe(1);
+    expect(loaded.countedChildIDs.ses_child).toBe(true);
+    expect(loaded.countedChildIDs["subtask:old"]).toBeUndefined();
+  });
 });

--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -38,7 +38,7 @@ function child(overrides: Partial<ChildSessionState> = {}): ChildSessionState {
 }
 
 describe("state", () => {
-  it("upserts running children, counts work once, and marks terminal statuses", () => {
+  it("upserts tool wrappers without counting them and marks terminal statuses", () => {
     useFrozenTime("2026-04-30T10:05:00.000Z");
     const state = createEmptyState();
 
@@ -51,27 +51,190 @@ describe("state", () => {
         startedAt: "2026-04-30T10:00:00.000Z",
       }),
     ).toBe(true);
-    expect(state.totalExecuted).toBe(1);
+    expect(state.totalExecuted).toBe(0);
+    expect(state.countedChildIDs["tool:part_1"]).toBeUndefined();
+    expect(state.children["tool:part_1"]).toBeDefined();
+
+    upsertRunningChild(state, {
+      id: "tool:part_1",
+      title: "Run tests",
+      parentID: "ses_parent",
+      source: "tool",
+      updatedAt: "2026-04-30T10:02:00.000Z",
+    });
+    expect(state.totalExecuted).toBe(0);
+    expect(state.countedChildIDs["tool:part_1"]).toBeUndefined();
 
     expect(
-      upsertRunningChild(state, {
-        id: "tool:part_1",
-        title: "Run tests",
-        parentID: "ses_parent",
-        source: "tool",
-      }),
-    ).toBe(false);
-    expect(state.totalExecuted).toBe(1);
-
-    expect(markChildStatus(state, "tool:part_1", "done", "2026-04-30T10:03:00.000Z")).toBe(
-      true,
-    );
+      markChildStatus(state, "tool:part_1", "done", "2026-04-30T10:03:00.000Z"),
+    ).toBe(true);
     expect(state.children["tool:part_1"]).toMatchObject({
       status: "done",
       color: "green",
       endedAt: "2026-04-30T10:03:00.000Z",
     });
+    expect(state.totalExecuted).toBe(0);
+    expect(state.countedChildIDs["tool:part_1"]).toBeUndefined();
     expect(getCounts(state)).toEqual({ running: 0, done: 1, error: 0 });
+  });
+
+  it("keeps non-zero-duration tool wrappers uncounted", () => {
+    const state = createEmptyState();
+
+    expect(
+      upsertRunningChild(state, {
+        id: "tool:part_2",
+        title: "Run longer delegated task",
+        parentID: "ses_parent",
+        source: "tool",
+        startedAt: "2026-04-30T10:00:00.000Z",
+        updatedAt: "2026-04-30T10:05:00.000Z",
+      }),
+    ).toBe(true);
+    markChildStatus(state, "tool:part_2", "done", "2026-04-30T10:05:00.000Z");
+    refreshDerivedFields(state, new Date("2026-04-30T10:05:00.000Z"));
+
+    expect(state.children["tool:part_2"].elapsedMs).toBe(300000);
+    expect(state.totalExecuted).toBe(0);
+    expect(state.countedChildIDs["tool:part_2"]).toBeUndefined();
+  });
+
+  it("counts real sessions exactly once even with repeated updates", () => {
+    const state = createEmptyState();
+
+    expect(
+      upsertRunningChild(state, {
+        id: "ses_child",
+        title: "Child work",
+        parentID: "ses_parent",
+        source: "session",
+      }),
+    ).toBe(true);
+    expect(state.totalExecuted).toBe(1);
+    expect(state.countedChildIDs.ses_child).toBe(true);
+
+    upsertRunningChild(state, {
+      id: "ses_child",
+      title: "Child work",
+      parentID: "ses_parent",
+      source: "session",
+      updatedAt: "2026-04-30T10:02:00.000Z",
+    });
+    expect(
+      markChildStatus(state, "ses_child", "done", "2026-04-30T10:03:00.000Z"),
+    ).toBe(true);
+
+    expect(state.totalExecuted).toBe(1);
+    expect(Object.keys(state.countedChildIDs)).toEqual(["ses_child"]);
+  });
+
+  it("counts a tool wrapper followed by a matching real session as one execution", () => {
+    const state = createEmptyState();
+
+    upsertRunningChild(state, {
+      id: "tool:part_1",
+      title: "Delegate work",
+      parentID: "ses_parent",
+      messageID: "msg_1",
+      source: "tool",
+      targetSessionID: "ses_child",
+    });
+    expect(state.totalExecuted).toBe(0);
+
+    upsertRunningChild(state, {
+      id: "ses_child",
+      title: "Child work",
+      parentID: "ses_parent",
+      messageID: "msg_1",
+      source: "session",
+    });
+
+    expect(state.totalExecuted).toBe(1);
+    expect(state.countedChildIDs.ses_child).toBe(true);
+    expect(state.countedChildIDs["tool:part_1"]).toBeUndefined();
+  });
+
+  it("counts subtask fallback only when it has no matching counted session", () => {
+    const state = createEmptyState();
+
+    upsertRunningChild(state, {
+      id: "subtask:part_1",
+      title: "Fallback work",
+      parentID: "ses_parent",
+      messageID: "msg_1",
+      source: "subtask",
+    });
+    expect(state.totalExecuted).toBe(1);
+    expect(state.countedChildIDs["subtask:part_1"]).toBe(true);
+
+    upsertRunningChild(state, {
+      id: "ses_other",
+      title: "Other child",
+      parentID: "ses_parent",
+      messageID: "msg_2",
+      source: "session",
+    });
+    upsertRunningChild(state, {
+      id: "subtask:part_2",
+      title: "Already counted fallback",
+      parentID: "ses_parent",
+      messageID: "msg_2",
+      source: "subtask",
+      targetSessionID: "ses_other",
+    });
+
+    expect(state.totalExecuted).toBe(2);
+    expect(state.countedChildIDs.ses_other).toBe(true);
+    expect(state.countedChildIDs["subtask:part_2"]).toBeUndefined();
+  });
+
+  it("rekeys counted subtask fallback when the matching session appears", () => {
+    const state = createEmptyState();
+
+    upsertRunningChild(state, {
+      id: "subtask:part_1",
+      title: "Fallback work",
+      parentID: "ses_parent",
+      messageID: "msg_1",
+      source: "subtask",
+    });
+    expect(state.totalExecuted).toBe(1);
+    expect(state.countedChildIDs["subtask:part_1"]).toBe(true);
+
+    upsertRunningChild(state, {
+      id: "ses_child",
+      title: "Child work",
+      parentID: "ses_parent",
+      messageID: "msg_1",
+      source: "session",
+    });
+
+    expect(state.totalExecuted).toBe(1);
+    expect(state.countedChildIDs.ses_child).toBe(true);
+    expect(state.countedChildIDs["subtask:part_1"]).toBeUndefined();
+  });
+
+  it("reconciles counted subtask fallback when details add a target session", () => {
+    const state = createEmptyState();
+
+    upsertRunningChild(state, {
+      id: "subtask:part_1",
+      title: "Fallback work",
+      parentID: "ses_parent",
+      messageID: "msg_1",
+      source: "subtask",
+    });
+    expect(state.totalExecuted).toBe(1);
+
+    expect(
+      upsertChildDetails(state, "subtask:part_1", {
+        targetSessionID: "ses_child",
+      }),
+    ).toBe(true);
+
+    expect(state.totalExecuted).toBe(1);
+    expect(state.countedChildIDs.ses_child).toBe(true);
+    expect(state.countedChildIDs["subtask:part_1"]).toBeUndefined();
   });
 
   it("merges details, sanitizes tokens, and refreshes elapsed fields", () => {
@@ -116,8 +279,13 @@ describe("state", () => {
       updatedAt: "2026-04-30T09:30:00.000Z",
     });
 
-    expect(pruneTerminalChildren(state, new Date("2026-04-30T10:00:01.000Z"))).toBe(1);
-    expect(Object.keys(state.children).sort()).toEqual(["recentDone", "running"]);
+    expect(
+      pruneTerminalChildren(state, new Date("2026-04-30T10:00:01.000Z")),
+    ).toBe(1);
+    expect(Object.keys(state.children).sort()).toEqual([
+      "recentDone",
+      "running",
+    ]);
   });
 
   it("resolves env paths and preserve-state flag", async () => {
@@ -136,12 +304,50 @@ describe("state", () => {
     state.countedChildIDs.ses_child = true;
 
     await saveState(harness.statePath, state);
-    expect(await readRuntimeState(harness.statePath)).toMatchObject({ totalExecuted: 1 });
-    expect(await loadState(harness.statePath)).toMatchObject({ totalExecuted: 1 });
+    expect(await readRuntimeState(harness.statePath)).toMatchObject({
+      totalExecuted: 1,
+    });
+    expect(await loadState(harness.statePath)).toMatchObject({
+      totalExecuted: 1,
+    });
 
     const badPath = join(harness.dir, "nested", "bad.json");
     await mkdir(dirname(badPath), { recursive: true });
     await writeFile(badPath, "not json", "utf8");
-    expect(await loadState(badPath)).toMatchObject({ children: {}, totalExecuted: 0 });
+    expect(await loadState(badPath)).toMatchObject({
+      children: {},
+      totalExecuted: 0,
+    });
+  });
+
+  it("does not add newly loaded tool wrappers while preserving historical tool counts", async () => {
+    const harness = await createRuntimeHarness();
+    await writeFile(
+      harness.statePath,
+      JSON.stringify({
+        children: {
+          "tool:old": child({
+            id: "tool:old",
+            source: "tool",
+            targetSessionID: undefined,
+          }),
+          "tool:new": child({
+            id: "tool:new",
+            source: "tool",
+            targetSessionID: undefined,
+          }),
+        },
+        countedChildIDs: { "tool:old": true },
+        totalExecuted: 1,
+        updatedAt: "2026-04-30T10:00:00.000Z",
+      }),
+      "utf8",
+    );
+
+    const loaded = await loadState(harness.statePath);
+
+    expect(loaded.totalExecuted).toBe(1);
+    expect(loaded.countedChildIDs["tool:old"]).toBe(true);
+    expect(loaded.countedChildIDs["tool:new"]).toBeUndefined();
   });
 });

--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -350,4 +350,51 @@ describe("state", () => {
     expect(loaded.countedChildIDs["tool:old"]).toBe(true);
     expect(loaded.countedChildIDs["tool:new"]).toBeUndefined();
   });
+
+  it("normalizes counters after loading missing counted ids", async () => {
+    const harness = await createRuntimeHarness();
+    await writeFile(
+      harness.statePath,
+      JSON.stringify({
+        children: {
+          ses_child: child({ id: "ses_child", source: "session" }),
+        },
+        countedChildIDs: {},
+        totalExecuted: 0,
+        updatedAt: "2026-04-30T10:00:00.000Z",
+      }),
+      "utf8",
+    );
+
+    const loaded = await loadState(harness.statePath);
+
+    expect(loaded.countedChildIDs.ses_child).toBe(true);
+    expect(loaded.totalExecuted).toBe(1);
+  });
+
+  it("rekeys historical counted subtasks to their loaded target session ids", async () => {
+    const harness = await createRuntimeHarness();
+    await writeFile(
+      harness.statePath,
+      JSON.stringify({
+        children: {
+          "subtask:old": child({
+            id: "subtask:old",
+            source: "subtask",
+            targetSessionID: "ses_child",
+          }),
+        },
+        countedChildIDs: { "subtask:old": true },
+        totalExecuted: 1,
+        updatedAt: "2026-04-30T10:00:00.000Z",
+      }),
+      "utf8",
+    );
+
+    const loaded = await loadState(harness.statePath);
+
+    expect(loaded.totalExecuted).toBe(1);
+    expect(loaded.countedChildIDs.ses_child).toBe(true);
+    expect(loaded.countedChildIDs["subtask:old"]).toBeUndefined();
+  });
 });

--- a/src/state.ts
+++ b/src/state.ts
@@ -100,28 +100,160 @@ function isTechnicalDelegationTitle(value: string | undefined): boolean {
   return /^delegation:\s+/i.test(value.trim());
 }
 
-function isCountableWorkItem(child: Pick<ChildSessionState, "id" | "title"> &
-  Partial<Pick<ChildSessionState, "source">>): boolean {
-  if (child.source === "tool" || child.source === "subtask") return true;
-  if (child.source === "session" || child.id.startsWith("ses_")) {
-    return !isTechnicalDelegationTitle(child.title);
+type CountableChildInput = Pick<
+  ChildSessionState,
+  "id" | "title" | "parentID"
+> &
+  Partial<Pick<ChildSessionState, "messageID" | "source" | "targetSessionID">>;
+
+function isRealSessionChild(
+  child: Pick<ChildSessionState, "id"> &
+    Partial<Pick<ChildSessionState, "source">>,
+): boolean {
+  return child.source === "session" || child.id.startsWith("ses_");
+}
+
+function isSyntheticToolWrapper(
+  child: Partial<Pick<ChildSessionState, "source">>,
+): boolean {
+  return child.source === "tool";
+}
+
+function isSubtaskFallback(
+  child: Partial<Pick<ChildSessionState, "source">>,
+): boolean {
+  return child.source === "subtask";
+}
+
+function matchingCorrelation(
+  left: Pick<ChildSessionState, "parentID"> &
+    Partial<Pick<ChildSessionState, "messageID">>,
+  right: Pick<ChildSessionState, "parentID"> &
+    Partial<Pick<ChildSessionState, "messageID">>,
+): boolean {
+  return Boolean(
+    left.messageID &&
+      right.messageID &&
+      left.parentID === right.parentID &&
+      left.messageID === right.messageID,
+  );
+}
+
+function findMatchingCountedSessionID(
+  state: StatuslineState,
+  subtask: CountableChildInput,
+): string | undefined {
+  if (
+    subtask.targetSessionID &&
+    state.countedChildIDs[subtask.targetSessionID]
+  ) {
+    return subtask.targetSessionID;
   }
+
+  const matchingSessionIDs = Object.values(state.children)
+    .filter((child) => isRealSessionChild(child))
+    .filter((child) => state.countedChildIDs[child.id])
+    .filter((child) => matchingCorrelation(subtask, child))
+    .map((child) => child.id);
+
+  return matchingSessionIDs.length === 1 ? matchingSessionIDs[0] : undefined;
+}
+
+function findMatchingCountedSubtaskID(
+  state: StatuslineState,
+  session: CountableChildInput,
+): string | undefined {
+  const matchingTargetSubtasks = Object.values(state.children)
+    .filter((child) => isSubtaskFallback(child))
+    .filter((child) => state.countedChildIDs[child.id])
+    .filter((child) => child.targetSessionID === session.id)
+    .map((child) => child.id);
+
+  if (matchingTargetSubtasks.length === 1) return matchingTargetSubtasks[0];
+
+  const matchingCorrelatedSubtasks = Object.values(state.children)
+    .filter((child) => isSubtaskFallback(child))
+    .filter((child) => state.countedChildIDs[child.id])
+    .filter((child) => matchingCorrelation(session, child))
+    .map((child) => child.id);
+
+  return matchingCorrelatedSubtasks.length === 1
+    ? matchingCorrelatedSubtasks[0]
+    : undefined;
+}
+
+function rekeyCountedExecution(
+  state: StatuslineState,
+  fromID: string,
+  toID: string,
+): boolean {
+  if (fromID === toID) return false;
+  normalizeExecutionCounters(state);
+  if (!state.countedChildIDs[fromID]) return false;
+
+  const toAlreadyCounted = Boolean(state.countedChildIDs[toID]);
+  delete state.countedChildIDs[fromID];
+  if (!toAlreadyCounted) {
+    state.countedChildIDs[toID] = true;
+    return true;
+  }
+
+  state.totalExecuted = Math.max(
+    Object.keys(state.countedChildIDs).length,
+    (toNonNegativeInteger(state.totalExecuted) ?? 0) - 1,
+  );
   return true;
 }
 
-function countChildExecution(state: StatuslineState, child: Pick<ChildSessionState, "id" | "title"> &
-  Partial<Pick<ChildSessionState, "source">>): boolean {
-  if (!isCountableWorkItem(child)) return false;
+function resolveExecutionCountIdentity(
+  state: StatuslineState,
+  child: CountableChildInput,
+): string | undefined {
+  if (isSyntheticToolWrapper(child)) return undefined;
+
+  if (isRealSessionChild(child)) {
+    if (isTechnicalDelegationTitle(child.title)) return undefined;
+    const matchingSubtaskID = findMatchingCountedSubtaskID(state, child);
+    if (matchingSubtaskID) {
+      rekeyCountedExecution(state, matchingSubtaskID, child.id);
+      return undefined;
+    }
+    return child.id;
+  }
+
+  if (isSubtaskFallback(child)) {
+    if (findMatchingCountedSessionID(state, child)) return undefined;
+    return child.targetSessionID ?? child.id;
+  }
+
+  return child.id;
+}
+
+function countChildExecution(
+  state: StatuslineState,
+  child: CountableChildInput,
+): boolean {
   normalizeExecutionCounters(state);
-  if (state.countedChildIDs[child.id]) return false;
+  const countIdentity = resolveExecutionCountIdentity(state, child);
+  if (!countIdentity) return false;
+  if (state.countedChildIDs[countIdentity]) return false;
 
   const previousTotal = Math.max(
     toNonNegativeInteger(state.totalExecuted) ?? 0,
     Object.keys(state.countedChildIDs).length,
   );
-  state.countedChildIDs[child.id] = true;
+  state.countedChildIDs[countIdentity] = true;
   state.totalExecuted = previousTotal + 1;
   return true;
+}
+
+function reconcileSubtaskTargetCount(
+  state: StatuslineState,
+  child: Pick<ChildSessionState, "id"> &
+    Partial<Pick<ChildSessionState, "source" | "targetSessionID">>,
+): boolean {
+  if (!isSubtaskFallback(child) || !child.targetSessionID) return false;
+  return rekeyCountedExecution(state, child.id, child.targetSessionID);
 }
 
 function sanitizeTokens(input: unknown): ChildTokenState | undefined {
@@ -195,7 +327,10 @@ function sanitizeSummary(value: unknown, title: string): string | undefined {
 
 function sanitizeAgentName(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
-  const agentName = value.replace(/^\((.*)\)$/, "$1").replace(/\s+/g, " ").trim();
+  const agentName = value
+    .replace(/^\((.*)\)$/, "$1")
+    .replace(/\s+/g, " ")
+    .trim();
   return agentName || undefined;
 }
 
@@ -210,7 +345,9 @@ function resolveElapsedMs(child: ChildSessionState, nowMs: number): number {
 }
 
 function terminalReferenceMs(child: ChildSessionState): number {
-  const parsed = Date.parse(child.endedAt ?? child.updatedAt ?? child.startedAt);
+  const parsed = Date.parse(
+    child.endedAt ?? child.updatedAt ?? child.startedAt,
+  );
   return Number.isNaN(parsed) ? 0 : parsed;
 }
 
@@ -239,7 +376,9 @@ export function pruneTerminalChildren(
     return pruned;
   }
 
-  terminalChildren.sort((a, b) => b.referenceMs - a.referenceMs || a.id.localeCompare(b.id));
+  terminalChildren.sort(
+    (a, b) => b.referenceMs - a.referenceMs || a.id.localeCompare(b.id),
+  );
   for (const child of terminalChildren.slice(MAX_TERMINAL_CHILDREN)) {
     delete state.children[child.id];
     pruned += 1;
@@ -260,9 +399,13 @@ export function refreshDerivedFields(
   for (const [id, child] of Object.entries(state.children)) {
     const startedAt = safeTimestamp(child.startedAt, nowISO);
     const updatedAt = safeTimestamp(child.updatedAt, nowISO);
-    const endedAt = child.endedAt ? safeTimestamp(child.endedAt, updatedAt) : undefined;
+    const endedAt = child.endedAt
+      ? safeTimestamp(child.endedAt, updatedAt)
+      : undefined;
     const status =
-      child.status === "done" || child.status === "error" || child.status === "running"
+      child.status === "done" ||
+      child.status === "error" ||
+      child.status === "running"
         ? child.status
         : "running";
 
@@ -356,19 +499,10 @@ export async function loadState(statePath: string): Promise<StatuslineState> {
     }
 
     const children =
-      parsed.children && typeof parsed.children === "object" ? parsed.children : {};
-
+      parsed.children && typeof parsed.children === "object"
+        ? parsed.children
+        : {};
     const countedChildIDs = sanitizeCountedChildIDs(parsed.countedChildIDs);
-    for (const [id, child] of Object.entries(children)) {
-      const candidate = child as Partial<ChildSessionState>;
-      if (typeof candidate.title === "string" && isCountableWorkItem({
-        id,
-        title: candidate.title,
-        source: candidate.source,
-      })) {
-        countedChildIDs[id] = true;
-      }
-    }
 
     const state: StatuslineState = {
       children: children as Record<string, ChildSessionState>,
@@ -382,6 +516,29 @@ export async function loadState(statePath: string): Promise<StatuslineState> {
           ? parsed.updatedAt
           : new Date().toISOString(),
     };
+
+    for (const [id, child] of Object.entries(children)) {
+      const candidate = child as Partial<ChildSessionState>;
+      if (
+        typeof candidate.title !== "string" ||
+        typeof candidate.parentID !== "string"
+      ) {
+        continue;
+      }
+      const targetSessionID = sanitizeTargetSessionID(
+        candidate.targetSessionID,
+        id.startsWith("ses_") ? id : undefined,
+      );
+      const countIdentity = resolveExecutionCountIdentity(state, {
+        id,
+        title: candidate.title,
+        parentID: candidate.parentID,
+        messageID: candidate.messageID,
+        source: candidate.source,
+        targetSessionID,
+      });
+      if (countIdentity) state.countedChildIDs[countIdentity] = true;
+    }
 
     refreshDerivedFields(state);
     return state;
@@ -419,17 +576,21 @@ export function upsertRunningChild(
   const observedUpdatedAt = safeTimestamp(input.updatedAt, now);
   const observedStartedAt = safeTimestamp(input.startedAt, observedUpdatedAt);
   const existing = state.children[input.id];
+  const targetSessionID = sanitizeTargetSessionID(
+    input.targetSessionID ?? existing?.targetSessionID,
+    input.id.startsWith("ses_") ? input.id : undefined,
+  );
+  const source = input.source ?? existing?.source ?? "session";
   const counted = existing
     ? false
     : countChildExecution(state, {
         id: input.id,
         title: input.title,
-        source: input.source,
+        parentID: input.parentID,
+        messageID: input.messageID,
+        source,
+        targetSessionID,
       });
-  const targetSessionID = sanitizeTargetSessionID(
-    input.targetSessionID ?? existing?.targetSessionID,
-    input.id.startsWith("ses_") ? input.id : undefined,
-  );
   const shouldKeepCompletedTiming =
     existing?.status === "done" || existing?.status === "error";
   const next: ChildSessionState = {
@@ -441,7 +602,7 @@ export function upsertRunningChild(
     agentName: sanitizeAgentName(input.agentName) ?? existing?.agentName,
     parentID: input.parentID,
     messageID: input.messageID ?? existing?.messageID,
-    source: input.source ?? existing?.source ?? "session",
+    source,
     targetSessionID,
     status: shouldKeepCompletedTiming ? existing.status : "running",
     color: statusColor(shouldKeepCompletedTiming ? existing.status : "running"),
@@ -471,6 +632,7 @@ export function upsertRunningChild(
   }
 
   state.children[input.id] = next;
+  reconcileSubtaskTargetCount(state, next);
   state.updatedAt = observedUpdatedAt;
   return true;
 }
@@ -490,7 +652,7 @@ export function markChildStatus(
 
     const observedEndedAt = endedAt
       ? safeTimestamp(endedAt, now)
-      : child.endedAt ?? now;
+      : (child.endedAt ?? now);
 
     if (
       child.status === status &&
@@ -544,7 +706,8 @@ export function upsertChildDetails(
   const nextSummary =
     sanitizeSummary(input.summary, nextTitle) ??
     sanitizeSummary(existing.summary, nextTitle);
-  const nextAgentName = sanitizeAgentName(input.agentName) ?? existing.agentName;
+  const nextAgentName =
+    sanitizeAgentName(input.agentName) ?? existing.agentName;
   const mergedTokens = mergeTokens(existing.tokens, input.tokens);
   const nextTargetSessionID = sanitizeTargetSessionID(
     input.targetSessionID ?? existing.targetSessionID,
@@ -562,7 +725,7 @@ export function upsertChildDetails(
 
   const now = new Date().toISOString();
   const observedUpdatedAt = safeTimestamp(input.updatedAt, now);
-  state.children[childID] = {
+  const next: ChildSessionState = {
     ...existing,
     title: nextTitle,
     summary: nextSummary,
@@ -571,6 +734,8 @@ export function upsertChildDetails(
     targetSessionID: nextTargetSessionID,
     updatedAt: observedUpdatedAt,
   };
+  state.children[childID] = next;
+  reconcileSubtaskTargetCount(state, next);
   state.updatedAt = observedUpdatedAt;
   return true;
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -537,9 +537,14 @@ export async function loadState(statePath: string): Promise<StatuslineState> {
         source: candidate.source,
         targetSessionID,
       });
-      if (countIdentity) state.countedChildIDs[countIdentity] = true;
+      if (countIdentity && countIdentity !== id && state.countedChildIDs[id]) {
+        rekeyCountedExecution(state, id, countIdentity);
+      } else if (countIdentity) {
+        state.countedChildIDs[countIdentity] = true;
+      }
     }
 
+    normalizeExecutionCounters(state);
     refreshDerivedFields(state);
     return state;
   } catch {

--- a/src/state.ts
+++ b/src/state.ts
@@ -529,6 +529,9 @@ export async function loadState(statePath: string): Promise<StatuslineState> {
         candidate.targetSessionID,
         id.startsWith("ses_") ? id : undefined,
       );
+      if (candidate.source === "subtask" && targetSessionID && state.countedChildIDs[id]) {
+        rekeyCountedExecution(state, id, targetSessionID);
+      }
       const countIdentity = resolveExecutionCountIdentity(state, {
         id,
         title: candidate.title,


### PR DESCRIPTION
Closes #50

## Summary

- Backfill target session IDs for live synchronous OpenCode `task` wrappers when the real session appears later.
- Broaden task output parsing for `ses_*` IDs.
- Collapse targetless generic task/delegate wrappers with the only real session sibling to avoid duplicate visible agents.

## Chain Context

Stacked PRs to main:

```text
main
└── PR 1: state counting semantics (#51)
    └── 📍 PR 2: sync task event/render collapse follow-up (this PR)
```

Base dependency: #51 must land first.
Start state: counters are deduplicated, but sync OpenCode `task` calls can still render duplicate wrapper/session rows.
End state: live sync task calls correlate or collapse to a single visible work item when safe.
Out of scope: broad TUI refactor or persisted historical counter migration.

## Changes

| File | Change |
|------|--------|
| `src/events.ts` | Adds fail-closed live backfill for targetless synthetic rows and broadens task output session-id parsing. |
| `src/events.test.ts` | Covers sync `task` before later `session.created` and output parser variants. |
| `src/render.ts` | Collapses a generic wrapper with the only real session sibling when stronger metadata is absent. |
| `src/render.test.ts` | Covers the remaining visible duplicate/stacked sync task case. |

## Validation

- [x] `pnpm test`
- [x] `pnpm typecheck`
- [x] `pnpm build`

## Checklist

- [x] I used a Conventional Commit title (e.g. `fix: ...`, `feat: ...`, `docs: ...`)
- [x] I linked related issue(s), or explained why none are needed
- [x] I did not include secrets, credentials, or private data
- [x] I called out any security-sensitive behavior changes
- [x] I updated docs when behavior or usage changed
