### PR TITLE
feat(security): harden npm supply chain and local persistence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22.13
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: 11.1.2
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -26,10 +26,16 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Typecheck
         run: pnpm typecheck
 
       - name: Test
         run: pnpm test
+
+      - name: Audit production dependencies
+        run: pnpm audit --prod --audit-level moderate
+
+      - name: Verify package contents
+        run: pnpm pack --dry-run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  id-token: write
 
 concurrency:
   group: release
@@ -27,7 +28,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 11.1.2
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -37,11 +38,18 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Audit production dependencies
+        run: pnpm audit --prod --audit-level moderate
+
+      - name: Verify package contents
+        run: pnpm pack --dry-run
 
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"
         run: pnpm exec semantic-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22.13
           cache: pnpm
           registry-url: https://registry.npmjs.org
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ dist/
 .DS_Store
 .atl/
 coverage/
+.pi/
+.pi-chain/
+security-audit/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,12 +15,12 @@ We aim to keep contributions simple, respectful, and easy to review.
 ### Requirements
 
 - Node.js 20+
-- pnpm 9+
+- pnpm 11.1.2
 
 ### Install
 
 ```sh
-pnpm install
+pnpm install --ignore-scripts
 ```
 
 ## Development Flow

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ We aim to keep contributions simple, respectful, and easy to review.
 
 ### Requirements
 
-- Node.js 20+
+- Node.js 22.13+
 - pnpm 11.1.2
 
 ### Install

--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ subagent.
 
 ## Local development
 
-Install dependencies:
+Install dependencies with lifecycle scripts disabled by default:
 
 ```sh
-pnpm install
+pnpm install --ignore-scripts
 ```
 
 Build the plugin:
@@ -133,6 +133,20 @@ pnpm test:watch
 pnpm test:coverage
 pnpm pack --dry-run
 ```
+
+## Security hardening for maintainers
+
+Recommended local npm/pnpm hygiene, following guidance from Gentle AI and Liran Tal:
+
+- install project dependencies with lifecycle scripts disabled when possible, for example `pnpm install --ignore-scripts`;
+- consider setting user-level `ignore-scripts=true` for npm/pnpm and temporarily opt in only when a trusted package needs scripts;
+- enable dependency age/cooldown policies where supported, for example `npm config set min-release-age 3` or equivalent Renovate/Dependabot cooldowns;
+- block or review git, tarball, URL, and other exotic dependency specs, for example `npm config set allow-git none` where supported;
+- optionally screen new packages with tools such as `npq` or Socket Firewall before adding them.
+
+These are maintainer/developer controls, not runtime enforcement by this plugin.
+
+Release maintainers should also keep npm trusted publishing/OIDC enabled for this package, require npm 2FA on maintainer accounts, restrict and revoke legacy npm tokens once OIDC publishing is active, and protect the release branch in GitHub.
 
 ## Testing
 
@@ -175,6 +189,14 @@ Then restart OpenCode.
 ### Token/context usage is missing
 
 OpenCode event payloads can vary by version and by event type. The plugin shows token/context usage when it is available and safely omits it when it is not.
+
+## Local privacy and persistence
+
+The plugin persists a local JSON state file and `status.txt` snapshot under `XDG_RUNTIME_DIR` or the system temp directory by default. Those files can include OpenCode-derived subagent titles and summaries, which may contain short fragments derived from prompts or task descriptions. Files are written best-effort with owner-only permissions and atomic temp-file replacement where Node and the host filesystem support them.
+
+`OPENCODE_SUBAGENT_STATUSLINE_STATE` overrides the state file path. Treat that environment variable as trusted local configuration because the plugin will write status data to the configured path.
+
+For token/context backfill, the TUI reads recent local OpenCode SQLite/log data only from the user's OpenCode data directory. Very large log files are skipped to avoid blocking the TUI.
 
 ---
 

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -1,0 +1,561 @@
+# Security hardening aplicado
+
+Este documento explica las medidas tomadas en la rama `security/npm-plugin-hardening`, por qué se aplicaron y qué efecto tienen.
+
+## 1. Worktree limpio desde `origin/main`
+
+**Qué se hizo**
+
+Se creó un worktree separado en:
+
+```text
+/home/joaquinvesapa/work/sub-agent-statusline-security-hardening
+```
+
+con la rama:
+
+```text
+security/npm-plugin-hardening
+```
+
+**Por qué**
+
+Había cambios locales de documentación en el worktree original. Para no mezclarlos con cambios de seguridad, se aisló el trabajo en una copia limpia basada en `origin/main`.
+
+**Qué protege**
+
+- Evita arrastrar cambios no relacionados.
+- Reduce riesgo de commitear documentación accidentalmente.
+- Hace que el diff de seguridad sea revisable.
+
+---
+
+## 2. `packageManager: pnpm@11.1.2`
+
+**Qué se hizo**
+
+En `package.json` se declaró:
+
+```json
+"packageManager": "pnpm@11.1.2"
+```
+
+También se actualizó CI y release para usar pnpm `11.1.2`.
+
+**Por qué**
+
+La versión del package manager forma parte de la cadena de suministro. Si cada entorno usa una versión distinta de pnpm, puede haber diferencias en resolución de dependencias, lockfile, instalación o comportamiento de seguridad.
+
+**Qué protege**
+
+- Builds más reproducibles.
+- Menos drift entre desarrollo local, CI y release.
+- Facilita investigar problemas porque todos usan la misma versión.
+
+---
+
+## 3. `engines.node: >=20`
+
+**Qué se hizo**
+
+En `package.json` se declaró:
+
+```json
+"engines": {
+  "node": ">=20"
+}
+```
+
+**Por qué**
+
+El proyecto ya apunta a Node 20 en build/CI. Declararlo explícitamente evita que usuarios o CI corran el plugin en runtimes no probados.
+
+**Qué protege**
+
+- Evita incompatibilidades silenciosas con versiones viejas de Node.
+- Reduce superficie de bugs por APIs modernas no disponibles.
+- Documenta el runtime soportado para consumidores del paquete.
+
+---
+
+## 4. Peer dependencies con rangos semver, no `*`
+
+**Qué se hizo**
+
+Se reemplazaron peers abiertos:
+
+```json
+"@opencode-ai/plugin": "*"
+```
+
+por rangos compatibles probados, por ejemplo:
+
+```json
+"@opencode-ai/plugin": ">=1.14.50 <2"
+```
+
+**Por qué**
+
+Un peer dependency con `*` acepta cualquier versión, incluso versiones no probadas, incompatibles o con vulnerabilidades conocidas.
+
+**Qué protege**
+
+- Limita combinaciones no testeadas.
+- Evita que el plugin se instale junto con majors potencialmente incompatibles.
+- Hace explícita la matriz de compatibilidad.
+
+---
+
+## 5. Installs en CI/release con `--ignore-scripts`
+
+**Qué se hizo**
+
+Los workflows ahora instalan dependencias con:
+
+```sh
+pnpm install --frozen-lockfile --ignore-scripts
+```
+
+**Por qué**
+
+Los lifecycle scripts de npm/pnpm (`preinstall`, `install`, `postinstall`) ejecutan código arbitrario durante la instalación. Son un vector clásico de supply-chain attacks.
+
+**Qué protege**
+
+- Bloquea ejecución automática de scripts de dependencias durante CI/release.
+- Reduce impacto si una dependencia o transitive dependency fue comprometida.
+- Sigue la práctica recomendada por Liran Tal y Gentle AI v1.28.3.
+
+**Trade-off**
+
+Si una dependencia legítima requiere scripts de instalación, el build podría fallar. En ese caso hay que permitirlo explícitamente y justificarlo.
+
+---
+
+## 6. Installs determinísticos con `--frozen-lockfile`
+
+**Qué se hizo**
+
+CI/release usan:
+
+```sh
+pnpm install --frozen-lockfile
+```
+
+**Por qué**
+
+El lockfile debe ser la fuente de verdad en CI. Si CI puede modificar o regenerar el lockfile, se pierde reproducibilidad.
+
+**Qué protege**
+
+- Evita drift de dependencias.
+- Detecta cuando `package.json` y `pnpm-lock.yaml` no están sincronizados.
+- Hace que PRs con cambios de dependencias sean visibles y revisables.
+
+---
+
+## 7. Audit productivo bloqueante
+
+**Qué se hizo**
+
+Se agregó en CI y release:
+
+```sh
+pnpm audit --prod --audit-level moderate
+```
+
+También se agregó script:
+
+```json
+"audit:prod": "pnpm audit --prod --audit-level moderate"
+```
+
+**Por qué**
+
+Queremos que vulnerabilidades moderadas o superiores en el árbol productivo bloqueen publicación/release.
+
+**Qué protege**
+
+- Evita publicar una versión con vulnerabilidades conocidas en dependencias runtime/peer instaladas.
+- Convierte vulnerabilidades en una señal visible y obligatoria antes del release.
+- Fuerza una decisión explícita: actualizar, esperar upstream o aceptar riesgo.
+
+**Estado actual**
+
+Este gate inicialmente fallaba por advisories upstream en `file-type` y `uuid`. Se resolvió actualizando las dependencias host/peer de desarrollo a versiones más nuevas y refrescando el lockfile para tomar el parche transitive de `uuid`:
+
+- `@opencode-ai/plugin >=1.14.50 <2`
+- `@opentui/core >=0.2.10 <0.3`
+- `@opentui/solid >=0.2.10 <0.3`
+- `uuid@13.0.2` en el lockfile transitivo de `effect`
+
+Después de esa actualización, tanto `pnpm audit --prod --audit-level moderate` como `pnpm audit --audit-level moderate` pasan sin vulnerabilidades conocidas. El gate queda bloqueante para evitar regressions en futuros cambios.
+
+---
+
+## 8. Verificación de contenido del paquete con `pnpm pack --dry-run`
+
+**Qué se hizo**
+
+Se agregó en CI/release:
+
+```sh
+pnpm pack --dry-run
+```
+
+También se agregó script:
+
+```json
+"pack:dry-run": "pnpm pack --dry-run"
+```
+
+**Por qué**
+
+No alcanza con mirar el repo: lo que importa es qué entra realmente en el tarball publicado a npm.
+
+**Qué protege**
+
+- Detecta archivos inesperados antes de publicar.
+- Ayuda a evitar subir secretos, artifacts locales o archivos de desarrollo.
+- Verifica que `files` en `package.json` limite correctamente el paquete.
+
+---
+
+## 9. `files` como superficie de publicación limitada
+
+**Qué existe / se preservó**
+
+El paquete publica solo:
+
+```json
+"files": [
+  "dist",
+  "assets",
+  "README.md"
+]
+```
+
+**Por qué**
+
+El allowlist de `files` es más seguro que depender de `.npmignore` o defaults implícitos.
+
+**Qué protege**
+
+- Reduce riesgo de publicar archivos internos.
+- Mantiene el paquete chico y auditable.
+- Hace más predecible el contenido publicado.
+
+---
+
+## 10. Provenance npm / OIDC
+
+**Qué se hizo**
+
+En release workflow:
+
+```yaml
+permissions:
+  id-token: write
+```
+
+Y:
+
+```yaml
+NPM_CONFIG_PROVENANCE: "true"
+```
+
+En `package.json`:
+
+```json
+"publishConfig": {
+  "access": "public",
+  "provenance": true
+}
+```
+
+**Por qué**
+
+La provenance permite que npm publique attestations que vinculan el paquete con el workflow de GitHub que lo generó. OIDC/trusted publishing reduce dependencia de tokens largos.
+
+**Qué protege**
+
+- Mejora trazabilidad del paquete publicado.
+- Permite verificar que el artifact salió del repo/workflow esperado.
+- Reduce riesgo asociado a tokens npm persistentes cuando trusted publishing esté configurado.
+
+**Acción externa pendiente**
+
+Esto prepara el repo, pero npm trusted publishing requiere configuración en npm/GitHub por parte de maintainers.
+
+---
+
+## 11. Recomendaciones para maintainers: 2FA, tokens y branch protection
+
+**Qué se documentó**
+
+Se agregaron notas para maintainers sobre:
+
+- activar 2FA en npm;
+- configurar trusted publishing/OIDC;
+- revocar o restringir tokens viejos una vez que OIDC esté activo;
+- proteger `main` con branch protection.
+
+**Por qué**
+
+Parte de la seguridad de npm no vive en el código: vive en cuentas, permisos y configuración del registry.
+
+**Qué protege**
+
+- Reduce riesgo de account takeover.
+- Reduce impacto de tokens filtrados.
+- Evita releases desde ramas o cambios no revisados.
+
+---
+
+## 12. Escritura atómica de `state.json` y `status.txt`
+
+**Qué se hizo**
+
+`saveState` y `saveStatusText` ahora escriben así:
+
+1. crear directorio si hace falta;
+2. escribir un archivo temporal en el mismo directorio;
+3. hacer `rename` al archivo final;
+4. limpiar el temporal si falla.
+
+**Por qué**
+
+Antes se sobrescribía directamente el archivo final. Si el proceso se interrumpía durante la escritura, podía quedar un JSON corrupto o un status parcial.
+
+**Qué protege**
+
+- Reduce riesgo de archivos parcialmente escritos.
+- Hace la actualización casi atómica dentro del mismo filesystem.
+- Mejora resiliencia ante interrupciones o errores de I/O.
+
+---
+
+## 13. Permisos owner-only para estado local
+
+**Qué se hizo**
+
+Los directorios se crean con modo aproximado:
+
+```text
+0700
+```
+
+Los archivos de estado/status con:
+
+```text
+0600
+```
+
+**Por qué**
+
+El estado local puede incluir títulos o resúmenes derivados de prompts/tareas. Eso puede ser sensible.
+
+**Qué protege**
+
+- Evita que otros usuarios locales lean el estado, si el sistema respeta permisos POSIX.
+- Reduce exposición accidental de fragmentos de prompts.
+- Alinea persistencia local con una postura privacy-first.
+
+**Nota**
+
+Los permisos son best-effort: dependen del sistema operativo, filesystem y umask.
+
+---
+
+## 14. Nombre temporal con `randomUUID()`
+
+**Qué se hizo**
+
+El archivo temporal incluye:
+
+- basename del archivo final;
+- PID;
+- timestamp;
+- `randomUUID()`.
+
+**Por qué**
+
+PID + timestamp puede colisionar en escrituras concurrentes muy rápidas. `randomUUID()` vuelve esa colisión prácticamente irrelevante.
+
+**Qué protege**
+
+- Evita que dos escrituras simultáneas pisen el mismo temp file.
+- Hace más segura la escritura atómica bajo concurrencia local.
+
+---
+
+## 15. `saveStatusText` compartido
+
+**Qué se hizo**
+
+Se reemplazaron escrituras directas de `status.txt` por un helper común:
+
+```ts
+saveStatusText(...)
+```
+
+**Por qué**
+
+Si `state.json` se escribía de forma segura pero `status.txt` seguía con `writeFile` directo, quedaba una brecha inconsistente.
+
+**Qué protege**
+
+- Aplica permisos y atomicidad también al snapshot de texto.
+- Evita duplicar lógica de filesystem.
+- Mantiene runtime y TUI con la misma política de escritura.
+
+---
+
+## 16. Límite de lectura para logs de OpenCode
+
+**Qué se hizo**
+
+Se agregó `src/logs.ts` con un helper que revisa tamaño antes de leer:
+
+```ts
+readOpenCodeLogFileIfSmall(...)
+```
+
+Si el log supera 1 MiB, se saltea.
+
+**Por qué**
+
+La TUI leía logs locales de forma síncrona para reconstruir tokens/contexto. Un log enorme podía bloquear la UI o consumir memoria innecesaria.
+
+**Qué protege**
+
+- Evita bloqueos por archivos muy grandes.
+- Reduce riesgo de degradación por logs locales anómalos.
+- Mantiene el backfill como best-effort: si el log es grande, se omite.
+
+---
+
+## 17. Documentación de privacidad local
+
+**Qué se documentó**
+
+En README se explicó que el plugin persiste:
+
+- `state.json`;
+- `status.txt`;
+- títulos/resúmenes derivados de eventos, prompts o tareas.
+
+También se explicó que:
+
+```text
+OPENCODE_SUBAGENT_STATUSLINE_STATE
+```
+
+es una variable confiable porque permite elegir dónde escribir estado.
+
+**Por qué**
+
+La seguridad no es solo bloquear ataques: también es hacer visibles los límites de privacidad.
+
+**Qué protege**
+
+- Evita sorpresas sobre datos persistidos localmente.
+- Ayuda a usuarios a elegir rutas seguras.
+- Deja claro que la variable de entorno no debe venir de fuentes no confiables.
+
+---
+
+## 18. Recomendaciones npm para desarrollo local
+
+**Qué se hizo**
+
+Se alinearon los comandos de documentación para preferir:
+
+```sh
+pnpm install --ignore-scripts
+```
+
+También se documentaron recomendaciones explícitas inspiradas en Gentle AI v1.28.3 y Liran Tal:
+
+```sh
+npm config set min-release-age 3
+npm config set allow-git none
+```
+
+Y herramientas opcionales de screening como:
+
+- `npq`
+- Socket Firewall
+
+**Por qué**
+
+La seguridad de supply chain no termina en CI. Los contributors también instalan dependencias localmente, y ese paso puede ejecutar código de terceros o incorporar releases demasiado recientes.
+
+**Qué protege**
+
+- Reduce ejecución accidental de lifecycle scripts durante desarrollo.
+- Da tiempo a que releases maliciosos o rotos sean detectados antes de ser adoptados.
+- Desalienta dependencias git/tarball/URL que saltean controles normales del registry.
+- Promueve revisar salud y riesgo de paquetes nuevos antes de agregarlos.
+
+**Nota**
+
+Estas recomendaciones son controles de maintainer/desarrollador. No son enforcement runtime del plugin.
+
+---
+
+## 19. Tests enfocados
+
+**Qué se hizo**
+
+Se agregaron/actualizaron tests para:
+
+- escritura de estado/status;
+- permisos esperados;
+- ausencia de temp files sobrantes;
+- skip de logs mayores a 1 MiB.
+
+**Por qué**
+
+Las medidas de seguridad deben quedar protegidas contra regresiones.
+
+**Qué protege**
+
+- Evita volver accidentalmente a `writeFile` directo.
+- Verifica que el helper de logs no lea archivos enormes.
+- Hace que los cambios sean mantenibles.
+
+---
+
+## 20. Limpieza de artifacts accidentales
+
+**Qué se hizo**
+
+Se eliminaron artifacts locales generados durante el trabajo y se agregaron a `.gitignore` para evitar que reaparezcan en un `git add .` accidental:
+
+- `.pi/`
+- `.pi-chain/`
+- `security-audit/`
+
+**Por qué**
+
+Eran archivos de harness/subagentes, no parte del plugin.
+
+**Qué protege**
+
+- Evita commitear ruido o archivos internos accidentalmente.
+- Mantiene el diff enfocado en seguridad real.
+
+---
+
+## Resumen ejecutivo
+
+Las medidas tomadas apuntan a cuatro áreas:
+
+1. **Supply chain npm**: pnpm fijo, installs determinísticos, `--ignore-scripts`, audit bloqueante, provenance.
+2. **Publicación segura**: tarball verificado, `publishConfig`, package contents limitado.
+3. **Runtime local seguro**: escrituras atómicas, permisos restrictivos, menos riesgo de corrupción o lectura local.
+4. **Privacidad/resiliencia TUI**: disclosure de estado persistido y límite para logs grandes.
+5. **Higiene de desarrollo local**: installs con scripts deshabilitados, cooldown de dependencias, bloqueo/revisión de dependencias exóticas y screening opcional.
+
+El audit productivo bloqueante queda activo y actualmente pasa sin vulnerabilidades conocidas después de actualizar las dependencias host/peer de desarrollo y refrescar transitivas parcheadas en el lockfile. Si vuelve a fallar en el futuro, la release debe detenerse hasta actualizar, justificar un override seguro o tomar una decisión explícita de riesgo.

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -54,7 +54,7 @@ La versión del package manager forma parte de la cadena de suministro. Si cada 
 
 ---
 
-## 3. `engines.node: >=20`
+## 3. `engines.node: >=22.13`
 
 **Qué se hizo**
 
@@ -62,13 +62,13 @@ En `package.json` se declaró:
 
 ```json
 "engines": {
-  "node": ">=20"
+  "node": ">=22.13"
 }
 ```
 
 **Por qué**
 
-El proyecto ya apunta a Node 20 en build/CI. Declararlo explícitamente evita que usuarios o CI corran el plugin en runtimes no probados.
+`pnpm@11.1.2` requiere Node.js `>=22.13` y usa módulos runtime como `node:sqlite` que no existen en Node 20. Declararlo explícitamente mantiene desarrollo, CI y release en un runtime compatible y probado.
 
 **Qué protege**
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -49,10 +49,10 @@ Keep assertions semantic. Prefer checking meaningful counters, titles, statuses,
 
 ## Running tests
 
-Install dependencies first:
+Install dependencies first with lifecycle scripts disabled by default:
 
 ```sh
-pnpm install
+pnpm install --ignore-scripts
 ```
 
 Run the full suite once:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-subagent-statusline",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "OpenCode plugin that exposes subagent session statusline state",
   "type": "module",
   "packageManager": "pnpm@11.1.2",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.6.0",
   "description": "OpenCode plugin that exposes subagent session statusline state",
   "type": "module",
+  "packageManager": "pnpm@11.1.2",
+  "engines": {
+    "node": ">=20"
+  },
   "main": "./dist/tui.js",
   "types": "./dist/tui.d.ts",
   "exports": {
@@ -24,10 +28,16 @@
     "assets",
     "README.md"
   ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "scripts": {
     "build": "tsup",
     "prepack": "pnpm run build",
     "release": "semantic-release",
+    "audit:prod": "pnpm audit --prod --audit-level moderate",
+    "pack:dry-run": "pnpm pack --dry-run",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
@@ -42,12 +52,15 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@opencode-ai/plugin": "*",
-    "@opentui/core": "*",
-    "@opentui/solid": "*",
-    "solid-js": "*"
+    "@opencode-ai/plugin": ">=1.14.50 <2",
+    "@opentui/core": ">=0.2.10 <0.3",
+    "@opentui/solid": ">=0.2.10 <0.3",
+    "solid-js": ">=1.9.12 <2"
   },
   "devDependencies": {
+    "@opencode-ai/plugin": "^1.14.50",
+    "@opentui/core": "^0.2.10",
+    "@opentui/solid": "^0.2.10",
     "@semantic-release/commit-analyzer": "^13.0.1",
     "@semantic-release/github": "^11.0.6",
     "@semantic-release/npm": "^12.0.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "packageManager": "pnpm@11.1.2",
   "engines": {
-    "node": ">=20"
+    "node": ">=22.13"
   },
   "main": "./dist/tui.js",
   "types": "./dist/tui.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,19 +8,19 @@ importers:
 
   .:
     dependencies:
-      '@opencode-ai/plugin':
-        specifier: '*'
-        version: 1.14.22(@opentui/core@0.1.103(stage-js@1.0.2)(typescript@5.9.3)(web-tree-sitter@0.25.10))(@opentui/solid@0.1.103(solid-js@1.9.12)(stage-js@1.0.2)(typescript@5.9.3)(web-tree-sitter@0.25.10))
-      '@opentui/core':
-        specifier: '*'
-        version: 0.1.103(stage-js@1.0.2)(typescript@5.9.3)(web-tree-sitter@0.25.10)
-      '@opentui/solid':
-        specifier: '*'
-        version: 0.1.103(solid-js@1.9.12)(stage-js@1.0.2)(typescript@5.9.3)(web-tree-sitter@0.25.10)
       solid-js:
-        specifier: '*'
+        specifier: '>=1.9.12 <2'
         version: 1.9.12
     devDependencies:
+      '@opencode-ai/plugin':
+        specifier: ^1.14.50
+        version: 1.14.50(@opentui/core@0.2.10(typescript@5.9.3)(web-tree-sitter@0.25.10))(@opentui/solid@0.2.10(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))
+      '@opentui/core':
+        specifier: ^0.2.10
+        version: 0.2.10(typescript@5.9.3)(web-tree-sitter@0.25.10)
+      '@opentui/solid':
+        specifier: ^0.2.10
+        version: 0.2.10(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@semantic-release/commit-analyzer':
         specifier: ^13.0.1
         version: 13.0.1(semantic-release@24.2.9(typescript@5.9.3))
@@ -47,7 +47,7 @@ importers:
         version: 24.2.9(typescript@5.9.3)
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.12)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.14)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
@@ -201,9 +201,6 @@ packages:
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
-
-  '@dimforge/rapier2d-simd-compat@0.17.3':
-    resolution: {integrity: sha512-bijvwWz6NHsNj5e5i1vtd3dU2pDhthSaTUZSh14DUGGKJfw8eMnlWZsxwHBxB/a3AXVNDjL9abuHw1k9FGR+jg==}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -370,118 +367,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@jimp/core@1.6.0':
-    resolution: {integrity: sha512-EQQlKU3s9QfdJqiSrZWNTxBs3rKXgO2W+GxNXDtwchF3a4IqxDheFX1ti+Env9hdJXDiYLp2jTRjlxhPthsk8w==}
-    engines: {node: '>=18'}
-
-  '@jimp/diff@1.6.0':
-    resolution: {integrity: sha512-+yUAQ5gvRC5D1WHYxjBHZI7JBRusGGSLf8AmPRPCenTzh4PA+wZ1xv2+cYqQwTfQHU5tXYOhA0xDytfHUf1Zyw==}
-    engines: {node: '>=18'}
-
-  '@jimp/file-ops@1.6.0':
-    resolution: {integrity: sha512-Dx/bVDmgnRe1AlniRpCKrGRm5YvGmUwbDzt+MAkgmLGf+jvBT75hmMEZ003n9HQI/aPnm/YKnXjg/hOpzNCpHQ==}
-    engines: {node: '>=18'}
-
-  '@jimp/js-bmp@1.6.0':
-    resolution: {integrity: sha512-FU6Q5PC/e3yzLyBDXupR3SnL3htU7S3KEs4e6rjDP6gNEOXRFsWs6YD3hXuXd50jd8ummy+q2WSwuGkr8wi+Gw==}
-    engines: {node: '>=18'}
-
-  '@jimp/js-gif@1.6.0':
-    resolution: {integrity: sha512-N9CZPHOrJTsAUoWkWZstLPpwT5AwJ0wge+47+ix3++SdSL/H2QzyMqxbcDYNFe4MoI5MIhATfb0/dl/wmX221g==}
-    engines: {node: '>=18'}
-
-  '@jimp/js-jpeg@1.6.0':
-    resolution: {integrity: sha512-6vgFDqeusblf5Pok6B2DUiMXplH8RhIKAryj1yn+007SIAQ0khM1Uptxmpku/0MfbClx2r7pnJv9gWpAEJdMVA==}
-    engines: {node: '>=18'}
-
-  '@jimp/js-png@1.6.0':
-    resolution: {integrity: sha512-AbQHScy3hDDgMRNfG0tPjL88AV6qKAILGReIa3ATpW5QFjBKpisvUaOqhzJ7Reic1oawx3Riyv152gaPfqsBVg==}
-    engines: {node: '>=18'}
-
-  '@jimp/js-tiff@1.6.0':
-    resolution: {integrity: sha512-zhReR8/7KO+adijj3h0ZQUOiun3mXUv79zYEAKvE0O+rP7EhgtKvWJOZfRzdZSNv0Pu1rKtgM72qgtwe2tFvyw==}
-    engines: {node: '>=18'}
-
-  '@jimp/plugin-blit@1.6.0':
-    resolution: {integrity: sha512-M+uRWl1csi7qilnSK8uxK4RJMSuVeBiO1AY0+7APnfUbQNZm6hCe0CCFv1Iyw1D/Dhb8ph8fQgm5mwM0eSxgVA==}
-    engines: {node: '>=18'}
-
-  '@jimp/plugin-blur@1.6.0':
-    resolution: {integrity: sha512-zrM7iic1OTwUCb0g/rN5y+UnmdEsT3IfuCXCJJNs8SZzP0MkZ1eTvuwK9ZidCuMo4+J3xkzCidRwYXB5CyGZTw==}
-    engines: {node: '>=18'}
-
-  '@jimp/plugin-circle@1.6.0':
-    resolution: {integrity: sha512-xt1Gp+LtdMKAXfDp3HNaG30SPZW6AQ7dtAtTnoRKorRi+5yCJjKqXRgkewS5bvj8DEh87Ko1ydJfzqS3P2tdWw==}
-    engines: {node: '>=18'}
-
-  '@jimp/plugin-color@1.6.0':
-    resolution: {integrity: sha512-J5q8IVCpkBsxIXM+45XOXTrsyfblyMZg3a9eAo0P7VPH4+CrvyNQwaYatbAIamSIN1YzxmO3DkIZXzRjFSz1SA==}
-    engines: {node: '>=18'}
-
-  '@jimp/plugin-contain@1.6.0':
-    resolution: {integrity: sha512-oN/n+Vdq/Qg9bB4yOBOxtY9IPAtEfES8J1n9Ddx+XhGBYT1/QTU/JYkGaAkIGoPnyYvmLEDqMz2SGihqlpqfzQ==}
-    engines: {node: '>=18'}
-
-  '@jimp/plugin-cover@1.6.0':
-    resolution: {integrity: sha512-Iow0h6yqSC269YUJ8HC3Q/MpCi2V55sMlbkkTTx4zPvd8mWZlC0ykrNDeAy9IJegrQ7v5E99rJwmQu25lygKLA==}
-    engines: {node: '>=18'}
-
-  '@jimp/plugin-crop@1.6.0':
-    resolution: {integrity: sha512-KqZkEhvs+21USdySCUDI+GFa393eDIzbi1smBqkUPTE+pRwSWMAf01D5OC3ZWB+xZsNla93BDS9iCkLHA8wang==}
-    engines: {node: '>=18'}
-
-  '@jimp/plugin-displace@1.6.0':
-    resolution: {integrity: sha512-4Y10X9qwr5F+Bo5ME356XSACEF55485j5nGdiyJ9hYzjQP9nGgxNJaZ4SAOqpd+k5sFaIeD7SQ0Occ26uIng5Q==}
-    engines: {node: '>=18'}
-
-  '@jimp/plugin-dither@1.6.0':
-    resolution: {integrity: sha512-600d1RxY0pKwgyU0tgMahLNKsqEcxGdbgXadCiVCoGd6V6glyCvkNrnnwC0n5aJ56Htkj88PToSdF88tNVZEEQ==}
-    engines: {node: '>=18'}
-
-  '@jimp/plugin-fisheye@1.6.0':
-    resolution: {integrity: sha512-E5QHKWSCBFtpgZarlmN3Q6+rTQxjirFqo44ohoTjzYVrDI6B6beXNnPIThJgPr0Y9GwfzgyarKvQuQuqCnnfbA==}
-    engines: {node: '>=18'}
-
-  '@jimp/plugin-flip@1.6.0':
-    resolution: {integrity: sha512-/+rJVDuBIVOgwoyVkBjUFHtP+wmW0r+r5OQ2GpatQofToPVbJw1DdYWXlwviSx7hvixTWLKVgRWQ5Dw862emDg==}
-    engines: {node: '>=18'}
-
-  '@jimp/plugin-hash@1.6.0':
-    resolution: {integrity: sha512-wWzl0kTpDJgYVbZdajTf+4NBSKvmI3bRI8q6EH9CVeIHps9VWVsUvEyb7rpbcwVLWYuzDtP2R0lTT6WeBNQH9Q==}
-    engines: {node: '>=18'}
-
-  '@jimp/plugin-mask@1.6.0':
-    resolution: {integrity: sha512-Cwy7ExSJMZszvkad8NV8o/Z92X2kFUFM8mcDAhNVxU0Q6tA0op2UKRJY51eoK8r6eds/qak3FQkXakvNabdLnA==}
-    engines: {node: '>=18'}
-
-  '@jimp/plugin-print@1.6.0':
-    resolution: {integrity: sha512-zarTIJi8fjoGMSI/M3Xh5yY9T65p03XJmPsuNet19K/Q7mwRU6EV2pfj+28++2PV2NJ+htDF5uecAlnGyxFN2A==}
-    engines: {node: '>=18'}
-
-  '@jimp/plugin-quantize@1.6.0':
-    resolution: {integrity: sha512-EmzZ/s9StYQwbpG6rUGBCisc3f64JIhSH+ncTJd+iFGtGo0YvSeMdAd+zqgiHpfZoOL54dNavZNjF4otK+mvlg==}
-    engines: {node: '>=18'}
-
-  '@jimp/plugin-resize@1.6.0':
-    resolution: {integrity: sha512-uSUD1mqXN9i1SGSz5ov3keRZ7S9L32/mAQG08wUwZiEi5FpbV0K8A8l1zkazAIZi9IJzLlTauRNU41Mi8IF9fA==}
-    engines: {node: '>=18'}
-
-  '@jimp/plugin-rotate@1.6.0':
-    resolution: {integrity: sha512-JagdjBLnUZGSG4xjCLkIpQOZZ3Mjbg8aGCCi4G69qR+OjNpOeGI7N2EQlfK/WE8BEHOW5vdjSyglNqcYbQBWRw==}
-    engines: {node: '>=18'}
-
-  '@jimp/plugin-threshold@1.6.0':
-    resolution: {integrity: sha512-M59m5dzLoHOVWdM41O8z9SyySzcDn43xHseOH0HavjsfQsT56GGCC4QzU1banJidbUrePhzoEdS42uFE8Fei8w==}
-    engines: {node: '>=18'}
-
-  '@jimp/types@1.6.0':
-    resolution: {integrity: sha512-7UfRsiKo5GZTAATxm2qQ7jqmUXP0DxTArztllTcYdyw6Xi5oT4RaoXynVtCD4UyLK5gJgkZJcwonoijrhYFKfg==}
-    engines: {node: '>=18'}
-
-  '@jimp/utils@1.6.0':
-    resolution: {integrity: sha512-gqFTGEosKbOkYF/WFj26jMHOI5OH2jeP1MmC/zbK6BF6VJBf8rIC5898dPfSzZEbSA0wbbV5slbntWVc5PKLFA==}
-    engines: {node: '>=18'}
-
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -585,59 +470,62 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
-  '@opencode-ai/plugin@1.14.22':
-    resolution: {integrity: sha512-lJlukegf5ECEHm9Y0NxCjXNfUArpPSUHP6hc+M4VCJ3NFk8uzzVsIXAzPS9Hvf2ltzjEYD/ulCOTi6pleeZ6yw==}
+  '@opencode-ai/plugin@1.14.50':
+    resolution: {integrity: sha512-2D4k6r8IFaAajEmezOZ3UKmRRGqEw2YzqotH5zLGT434yKtabduEsQgXa0fWlASut4FVT3JURhq5LqeBUV/k4g==}
     peerDependencies:
-      '@opentui/core': '>=0.1.99'
-      '@opentui/solid': '>=0.1.99'
+      '@opentui/core': '>=0.2.9'
+      '@opentui/keymap': '>=0.2.9'
+      '@opentui/solid': '>=0.2.9'
     peerDependenciesMeta:
       '@opentui/core':
+        optional: true
+      '@opentui/keymap':
         optional: true
       '@opentui/solid':
         optional: true
 
-  '@opencode-ai/sdk@1.14.22':
-    resolution: {integrity: sha512-1PjkrZRAwm9ocfTwOleP/e31HYtLVODb2E1hYTRHMmvF2rmAdCm7lztguYVkAPn/B6koGpFvhslTQH7j+38Fjw==}
+  '@opencode-ai/sdk@1.14.50':
+    resolution: {integrity: sha512-IrTKTFviR4Tj+u0BI8h8XgXIvEpxwkkHqBj6E0aEc4DBErpS3qh2Lkp1xt0OdtCYiLE3wZ1bAIiHOiO66H/7TA==}
 
-  '@opentui/core-darwin-arm64@0.1.103':
-    resolution: {integrity: sha512-lxCyedDkcen12IgBtXjkJ7iY66xa7VC4nxRNKCUeLY2ZP9hUE1AsDtbyQzqY+BQadsI/ZME9STzaHDCUFg0TpA==}
+  '@opentui/core-darwin-arm64@0.2.10':
+    resolution: {integrity: sha512-+lbDDj42Og+UtTZEwlHhGXichmOlkxSqn0J+Jqjat5/Tt5oZykj1NZjFIQ7ZSz4Miz7EmZwgYKE2CyOmmm9MoQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@opentui/core-darwin-x64@0.1.103':
-    resolution: {integrity: sha512-QMYD+zUDGQliJ6m5nuNvA72jtluFeyVMoHkuA5m/Xmed/u8eLfahAKmDj3kY66ntUroPHWevcpbpvd7NCFEoFQ==}
+  '@opentui/core-darwin-x64@0.2.10':
+    resolution: {integrity: sha512-5iAoA0aqMWWAQ93nh8Bb0ipwt9h+tvEFc88+YO9St43uUJ+XrXcmMj3T8wtl6dSu/SN0UoDWNaUMHUmtykiPtg==}
     cpu: [x64]
     os: [darwin]
 
-  '@opentui/core-linux-arm64@0.1.103':
-    resolution: {integrity: sha512-GzOvNr9dN6JaQ9qs7m8E75wLAHwT5CyxqkE6rEr1BO23/d2Ix7e3GYw/JRY5VnTge+eXrfDVbqNtPcQamUNiEA==}
+  '@opentui/core-linux-arm64@0.2.10':
+    resolution: {integrity: sha512-EnrkxgH5K76Oi/Br1UHPZblXG5P60snmtySfnxuVaeECNZrbTkV6BV/A0WoBeWshJweGbx1D+eTF+sEEjQCi8w==}
     cpu: [arm64]
     os: [linux]
 
-  '@opentui/core-linux-x64@0.1.103':
-    resolution: {integrity: sha512-odywllco5zUKNc60uD3JKaCybK64u6BfmpScs4a8Qn89yH/yk23bzWXDRWaGgQdY65L2/VCbcGs1ezA1S/2YTw==}
+  '@opentui/core-linux-x64@0.2.10':
+    resolution: {integrity: sha512-fI+r3kCPqIxsWwPVGpKUQy4zHK8y+jkDRCwa3UbaUy48RQ44jMuf2RhVhmi4xmCvSc8UPJBbYsw1tLuh9kmXjg==}
     cpu: [x64]
     os: [linux]
 
-  '@opentui/core-win32-arm64@0.1.103':
-    resolution: {integrity: sha512-tZL5w3Y0JnO7RkIvfuNDAzJn0j6+JIYl6M8DgPM5p8AQt+162S8LmbumzmqQLZl4cEev2eN7/tw72WIk6b+/CQ==}
+  '@opentui/core-win32-arm64@0.2.10':
+    resolution: {integrity: sha512-8F4z2hIRgkVWcr6CMVeJ9N4+1rmURPt2Pq2GBPko8ch6rxHR+a//KD1MfphyuLTHBS1tJ4vfZSWSoiaESImtrA==}
     cpu: [arm64]
     os: [win32]
 
-  '@opentui/core-win32-x64@0.1.103':
-    resolution: {integrity: sha512-wqnibt/OE5ldSzVPxEbriA0TjI2B11CJl4uJoLxTZ47KDx7tAFIMdhBf9IRAGNCSbcDuZ8ZGEFhV+SLaftkrlw==}
+  '@opentui/core-win32-x64@0.2.10':
+    resolution: {integrity: sha512-Ki+qNBlIFW5K2wcG/RHrlPp7yEQKXeiNX3mlje25iwX62Ac5w391HBpOmUjbPoq20McPyDRnhbLfbXQSPtickg==}
     cpu: [x64]
     os: [win32]
 
-  '@opentui/core@0.1.103':
-    resolution: {integrity: sha512-PWVv/bDmlk1i6X1f0zXs+jSaTrQ/ByX8wFbP2WinOObTGf//UbcRP4dbWxPXvOyka9QlmRBG/7GbloQSIStyVw==}
+  '@opentui/core@0.2.10':
+    resolution: {integrity: sha512-oviCtx0jYjc7F8X2b8+0IkQLg6WH47Nwl6CFeZo5dU0k6OpSbTbi07ZleObaiECAp+S1YLhAtVdgzHU7hBZlaw==}
     peerDependencies:
       web-tree-sitter: 0.25.10
 
-  '@opentui/solid@0.1.103':
-    resolution: {integrity: sha512-L28WFBs17Z5JXkJhPagLy8tUamkttDaaQDdb2KEO01IQ9r81yLBRpYqD/lHp6UoSISXgwQVDQ9yNtxwR1BQZvQ==}
+  '@opentui/solid@0.2.10':
+    resolution: {integrity: sha512-+4/MB90yIQiPwg8Y4wY092yva9BvRTsJeeeEO3e2H7P8k8zxYk4G9bzuhqYLxA9mTVQ+zVDlrmFoPQhT7vpIRw==}
     peerDependencies:
-      solid-js: 1.9.11
+      solid-js: 1.9.12
 
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
@@ -936,11 +824,8 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@tokenizer/token@0.3.0':
-    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
-
-  '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -950,9 +835,6 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
-
-  '@types/node@16.9.1':
-    resolution: {integrity: sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==}
 
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
@@ -998,13 +880,6 @@ packages:
   '@vitest/utils@4.1.5':
     resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
-  '@webgpu/types@0.1.69':
-    resolution: {integrity: sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==}
-
-  abort-controller@3.0.0:
-    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
-    engines: {node: '>=6.5'}
-
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
@@ -1038,9 +913,6 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
-  any-base@1.1.0:
-    resolution: {integrity: sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==}
-
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
@@ -1060,10 +932,6 @@ packages:
   ast-v8-to-istanbul@1.0.0:
     resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
-  await-to-js@3.0.0:
-    resolution: {integrity: sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g==}
-    engines: {node: '>=6.0.0'}
-
   babel-plugin-jsx-dom-expressions@0.40.6:
     resolution: {integrity: sha512-v3P1MW46Lm7VMpAkq0QfyzLWWkC8fh+0aE5Km4msIgDx5kjenHU0pF2s+4/NH8CQn/kla6+Hvws+2AF7bfV5qQ==}
     peerDependencies:
@@ -1081,11 +949,17 @@ packages:
       solid-js:
         optional: true
 
+  babel-preset-solid@1.9.12:
+    resolution: {integrity: sha512-LLqnuKVDlKpyBlMPcH6qEvs/wmS9a+NczppxJ3ryS/c0O5IiSFOIBQi9GzyiGDSbcJpx4Gr87jyFTos1MyEuWg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+      solid-js: ^1.9.12
+    peerDependenciesMeta:
+      solid-js:
+        optional: true
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
-  base64-js@1.5.1:
-    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
   baseline-browser-mapping@2.10.21:
     resolution: {integrity: sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==}
@@ -1094,9 +968,6 @@ packages:
 
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
-
-  bmp-ts@1.0.9:
-    resolution: {integrity: sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw==}
 
   bottleneck@2.19.5:
     resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
@@ -1113,36 +984,10 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
-  buffer@6.0.3:
-    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
-
-  bun-ffi-structs@0.1.2:
-    resolution: {integrity: sha512-Lh1oQAYHDcnesJauieA4UNkWGXY9hYck7OA5IaRwE3Bp6K2F2pJSNYqq+hIy7P3uOvo3km3oxS8304g5gDMl/w==}
+  bun-ffi-structs@0.2.2:
+    resolution: {integrity: sha512-N/ZWtyN0piZlrXQT7TO0V+q952orYqkfhXRXM1Hcbb+R3QSiBH4vLnib187Mrs1H7pWIYECAmPeapGYDOMCl+w==}
     peerDependencies:
       typescript: ^5
-
-  bun-webgpu-darwin-arm64@0.1.6:
-    resolution: {integrity: sha512-lIsDkPzJzPl6yrB5CUOINJFPnTRv6fF/Q8J1mAr43ogSp86WZEg9XZKaT6f3EUJ+9ETogGoMnoj1q0AwHUTbAQ==}
-    cpu: [arm64]
-    os: [darwin]
-
-  bun-webgpu-darwin-x64@0.1.6:
-    resolution: {integrity: sha512-uEddf5U7GvKIkM/BV18rUKtYHL6d0KeqBjNHwfqDH9QgEo9KVSKvJXS5I/sMefk5V5pIYE+8tQhtrREevhocng==}
-    cpu: [x64]
-    os: [darwin]
-
-  bun-webgpu-linux-x64@0.1.6:
-    resolution: {integrity: sha512-Y/f15j9r8ba0xUz+3lATtS74OE+PPzQXO7Do/1eCluJcuOlfa77kMjvBK/ShWnem3Y9xqi59pebTPOGRB+CaJA==}
-    cpu: [x64]
-    os: [linux]
-
-  bun-webgpu-win32-x64@0.1.6:
-    resolution: {integrity: sha512-MHSFAKqizISb+C5NfDrFe3g0Al5Njnu0j/A+oO2Q+bIWX+fUYjBSowiYE1ZXJx65KuryuB+tiM7Qh6cQbVvkEg==}
-    cpu: [x64]
-    os: [win32]
-
-  bun-webgpu@0.1.5:
-    resolution: {integrity: sha512-91/K6S5whZKX7CWAm9AylhyKrLGRz6BUiiPiM/kXadSnD4rffljCD/q9cNFftm5YXhx4MvLqw33yEilxogJvwA==}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -1300,8 +1145,8 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  diff@8.0.2:
-    resolution: {integrity: sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==}
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
     engines: {node: '>=0.3.1'}
 
   dir-glob@3.0.1:
@@ -1315,11 +1160,14 @@ packages:
   duplexer2@0.1.4:
     resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
 
-  effect@4.0.0-beta.48:
-    resolution: {integrity: sha512-MMAM/ZabuNdNmgXiin+BAanQXK7qM8mlt7nfXDoJ/Gn9V8i89JlCq+2N0AiWmqFLXjGLA0u3FjiOjSOYQk5uMw==}
+  effect@4.0.0-beta.65:
+    resolution: {integrity: sha512-QYKvQPAj3CmtsvWkHQww15wX4KG2gNsszDWEcOO5sZCMknp66u6Si/Opmt3wwWCwsyvRmDAdIg+JIz5qzbbFIw==}
 
   electron-to-chromium@1.5.344:
     resolution: {integrity: sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==}
+
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -1383,14 +1231,6 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
-  event-target-shim@5.0.1:
-    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
-    engines: {node: '>=6'}
-
-  events@3.3.0:
-    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
-    engines: {node: '>=0.8.x'}
-
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
@@ -1398,9 +1238,6 @@ packages:
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
-
-  exif-parser@0.1.12:
-    resolution: {integrity: sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw==}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -1429,10 +1266,6 @@ packages:
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
-
-  file-type@16.5.4:
-    resolution: {integrity: sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==}
-    engines: {node: '>=10'}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -1493,6 +1326,10 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
@@ -1508,9 +1345,6 @@ packages:
   get-stream@9.0.1:
     resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
     engines: {node: '>=18'}
-
-  gifwrap@0.10.1:
-    resolution: {integrity: sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw==}
 
   git-log-parser@1.2.1:
     resolution: {integrity: sha512-PI+sPDvHXNPl5WNOErAK05s3j0lgwUzMN6o8cyQrDaKfT3qd7TmNJKeXX+SknI5I0QhG5fVPAEwSY4tRGDtYoQ==}
@@ -1579,12 +1413,6 @@ packages:
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
-
-  ieee754@1.2.1:
-    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
-
-  image-q@4.0.0:
-    resolution: {integrity: sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -1680,16 +1508,9 @@ packages:
     resolution: {integrity: sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==}
     engines: {node: '>= 0.6.0'}
 
-  jimp@1.6.0:
-    resolution: {integrity: sha512-YcwCHw1kiqEeI5xRpDlPPBGL2EOpBKLwO4yIBJcXWHPj5PnA5urGq0jbyhM5KoNpypQ6VboSoxc9D8HyfvngSg==}
-    engines: {node: '>=18'}
-
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
-
-  jpeg-js@0.4.4:
-    resolution: {integrity: sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==}
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
@@ -1888,11 +1709,6 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
-  mime@3.0.0:
-    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
-    engines: {node: '>=10.0.0'}
-    hasBin: true
-
   mime@4.1.0:
     resolution: {integrity: sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==}
     engines: {node: '>=16'}
@@ -1936,8 +1752,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2055,9 +1871,6 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
-  omggif@1.0.10:
-    resolution: {integrity: sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==}
-
   onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
@@ -2114,21 +1927,9 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
-  pako@1.0.11:
-    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
-
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
-
-  parse-bmfont-ascii@1.0.6:
-    resolution: {integrity: sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA==}
-
-  parse-bmfont-binary@1.0.6:
-    resolution: {integrity: sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA==}
-
-  parse-bmfont-xml@1.1.6:
-    resolution: {integrity: sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA==}
 
   parse-json@4.0.0:
     resolution: {integrity: sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==}
@@ -2184,10 +1985,6 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
-  peek-readable@4.1.0:
-    resolution: {integrity: sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==}
-    engines: {node: '>=8'}
-
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2207,10 +2004,6 @@ packages:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
 
-  pixelmatch@5.3.0:
-    resolution: {integrity: sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==}
-    hasBin: true
-
   pkg-conf@2.1.0:
     resolution: {integrity: sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==}
     engines: {node: '>=4'}
@@ -2221,20 +2014,6 @@ packages:
   pkg-up@3.1.0:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
     engines: {node: '>=8'}
-
-  planck@1.5.0:
-    resolution: {integrity: sha512-dlvqJE+FscZgrGUXJ5ybd0o5bvZ5XXyZNbm08xGsXp9WjXeAyWSFT6n9s/1PQcUBo4546fDXA5RMA4wbDyZw6g==}
-    engines: {node: '>=24.0'}
-    peerDependencies:
-      stage-js: ^1.0.0-alpha.12
-
-  pngjs@6.0.0:
-    resolution: {integrity: sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==}
-    engines: {node: '>=12.13.0'}
-
-  pngjs@7.0.0:
-    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
-    engines: {node: '>=14.19.0'}
 
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
@@ -2254,8 +2033,8 @@ packages:
       yaml:
         optional: true
 
-  postcss@8.5.12:
-    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
   pretty-ms@9.3.0:
@@ -2264,10 +2043,6 @@ packages:
 
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
-
-  process@0.11.10:
-    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
-    engines: {node: '>= 0.6.0'}
 
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
@@ -2289,14 +2064,6 @@ packages:
 
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
-
-  readable-stream@4.7.0:
-    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
-  readable-web-to-node-stream@3.0.4:
-    resolution: {integrity: sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==}
-    engines: {node: '>=8'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -2341,13 +2108,6 @@ packages:
 
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
-
-  safe-buffer@5.2.1:
-    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-
-  sax@1.6.0:
-    resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
-    engines: {node: '>=11.0.0'}
 
   semantic-release@24.2.9:
     resolution: {integrity: sha512-phCkJ6pjDi9ANdhuF5ElS10GGdAKY6R1Pvt9lT3SFhOwM4T7QZE7MLpBDbNruUx/Q3gFD92/UOFringGipRqZA==}
@@ -2401,10 +2161,6 @@ packages:
     resolution: {integrity: sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==}
     engines: {node: '>=6'}
 
-  simple-xml-to-json@1.2.7:
-    resolution: {integrity: sha512-mz9VXphOxQWX3eQ/uXCtm6upltoN0DLx8Zb5T4TFC4FHB7S9FDPGre8CfLWqPWQQH/GrQYd2AXhhVM5LDpYx6Q==}
-    engines: {node: '>=20.12.2'}
-
   skin-tone@2.0.0:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
     engines: {node: '>=8'}
@@ -2445,10 +2201,6 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  stage-js@1.0.2:
-    resolution: {integrity: sha512-EWTRBYlg7Qv9wGUao99/PfRe3KaiQqWmgSvTOXvaWnu1Jk/q/vV8yJVu6bi/3EqDZeMVnCPAjheba6OFc5k1GQ==}
-    engines: {node: '>=24.0'}
-
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
@@ -2459,15 +2211,20 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
-
-  string_decoder@1.3.0:
-    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-ansi@7.1.2:
+    resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
+    engines: {node: '>=12'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -2484,10 +2241,6 @@ packages:
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
-
-  strtok3@6.3.0:
-    resolution: {integrity: sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==}
-    engines: {node: '>=10'}
 
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
@@ -2529,9 +2282,6 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
-  three@0.177.0:
-    resolution: {integrity: sha512-EiXv5/qWAaGI+Vz2A+JfavwYCMdGjxVsrn3oBwllUoqYeaBO75J63ZfyaQKoiLrqNHoTlUc6PFgMXnS0kI45zg==}
-
   through2@2.0.5:
     resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
 
@@ -2541,9 +2291,6 @@ packages:
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
-
-  tinycolor2@1.6.0:
-    resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
@@ -2563,10 +2310,6 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
-
-  token-types@4.2.1:
-    resolution: {integrity: sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==}
-    engines: {node: '>=10'}
 
   toml@4.1.1:
     resolution: {integrity: sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==}
@@ -2666,14 +2409,11 @@ packages:
     resolution: {integrity: sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  utif2@4.1.0:
-    resolution: {integrity: sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w==}
-
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@13.0.0:
-    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
+  uuid@13.0.2:
+    resolution: {integrity: sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==}
     hasBin: true
 
   validate-npm-package-license@3.0.4:
@@ -2791,17 +2531,6 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
-  xml-parse-from-string@1.0.1:
-    resolution: {integrity: sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==}
-
-  xml2js@0.5.0:
-    resolution: {integrity: sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==}
-    engines: {node: '>=4.0.0'}
-
-  xmlbuilder@11.0.1:
-    resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
-    engines: {node: '>=4.0'}
-
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -2840,9 +2569,6 @@ packages:
 
   yoga-layout@3.2.1:
     resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
-
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.1.8:
     resolution: {integrity: sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==}
@@ -3049,9 +2775,6 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@dimforge/rapier2d-simd-compat@0.17.3':
-    optional: true
-
   '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -3146,195 +2869,6 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
-  '@jimp/core@1.6.0':
-    dependencies:
-      '@jimp/file-ops': 1.6.0
-      '@jimp/types': 1.6.0
-      '@jimp/utils': 1.6.0
-      await-to-js: 3.0.0
-      exif-parser: 0.1.12
-      file-type: 16.5.4
-      mime: 3.0.0
-
-  '@jimp/diff@1.6.0':
-    dependencies:
-      '@jimp/plugin-resize': 1.6.0
-      '@jimp/types': 1.6.0
-      '@jimp/utils': 1.6.0
-      pixelmatch: 5.3.0
-
-  '@jimp/file-ops@1.6.0': {}
-
-  '@jimp/js-bmp@1.6.0':
-    dependencies:
-      '@jimp/core': 1.6.0
-      '@jimp/types': 1.6.0
-      '@jimp/utils': 1.6.0
-      bmp-ts: 1.0.9
-
-  '@jimp/js-gif@1.6.0':
-    dependencies:
-      '@jimp/core': 1.6.0
-      '@jimp/types': 1.6.0
-      gifwrap: 0.10.1
-      omggif: 1.0.10
-
-  '@jimp/js-jpeg@1.6.0':
-    dependencies:
-      '@jimp/core': 1.6.0
-      '@jimp/types': 1.6.0
-      jpeg-js: 0.4.4
-
-  '@jimp/js-png@1.6.0':
-    dependencies:
-      '@jimp/core': 1.6.0
-      '@jimp/types': 1.6.0
-      pngjs: 7.0.0
-
-  '@jimp/js-tiff@1.6.0':
-    dependencies:
-      '@jimp/core': 1.6.0
-      '@jimp/types': 1.6.0
-      utif2: 4.1.0
-
-  '@jimp/plugin-blit@1.6.0':
-    dependencies:
-      '@jimp/types': 1.6.0
-      '@jimp/utils': 1.6.0
-      zod: 3.25.76
-
-  '@jimp/plugin-blur@1.6.0':
-    dependencies:
-      '@jimp/core': 1.6.0
-      '@jimp/utils': 1.6.0
-
-  '@jimp/plugin-circle@1.6.0':
-    dependencies:
-      '@jimp/types': 1.6.0
-      zod: 3.25.76
-
-  '@jimp/plugin-color@1.6.0':
-    dependencies:
-      '@jimp/core': 1.6.0
-      '@jimp/types': 1.6.0
-      '@jimp/utils': 1.6.0
-      tinycolor2: 1.6.0
-      zod: 3.25.76
-
-  '@jimp/plugin-contain@1.6.0':
-    dependencies:
-      '@jimp/core': 1.6.0
-      '@jimp/plugin-blit': 1.6.0
-      '@jimp/plugin-resize': 1.6.0
-      '@jimp/types': 1.6.0
-      '@jimp/utils': 1.6.0
-      zod: 3.25.76
-
-  '@jimp/plugin-cover@1.6.0':
-    dependencies:
-      '@jimp/core': 1.6.0
-      '@jimp/plugin-crop': 1.6.0
-      '@jimp/plugin-resize': 1.6.0
-      '@jimp/types': 1.6.0
-      zod: 3.25.76
-
-  '@jimp/plugin-crop@1.6.0':
-    dependencies:
-      '@jimp/core': 1.6.0
-      '@jimp/types': 1.6.0
-      '@jimp/utils': 1.6.0
-      zod: 3.25.76
-
-  '@jimp/plugin-displace@1.6.0':
-    dependencies:
-      '@jimp/types': 1.6.0
-      '@jimp/utils': 1.6.0
-      zod: 3.25.76
-
-  '@jimp/plugin-dither@1.6.0':
-    dependencies:
-      '@jimp/types': 1.6.0
-
-  '@jimp/plugin-fisheye@1.6.0':
-    dependencies:
-      '@jimp/types': 1.6.0
-      '@jimp/utils': 1.6.0
-      zod: 3.25.76
-
-  '@jimp/plugin-flip@1.6.0':
-    dependencies:
-      '@jimp/types': 1.6.0
-      zod: 3.25.76
-
-  '@jimp/plugin-hash@1.6.0':
-    dependencies:
-      '@jimp/core': 1.6.0
-      '@jimp/js-bmp': 1.6.0
-      '@jimp/js-jpeg': 1.6.0
-      '@jimp/js-png': 1.6.0
-      '@jimp/js-tiff': 1.6.0
-      '@jimp/plugin-color': 1.6.0
-      '@jimp/plugin-resize': 1.6.0
-      '@jimp/types': 1.6.0
-      '@jimp/utils': 1.6.0
-      any-base: 1.1.0
-
-  '@jimp/plugin-mask@1.6.0':
-    dependencies:
-      '@jimp/types': 1.6.0
-      zod: 3.25.76
-
-  '@jimp/plugin-print@1.6.0':
-    dependencies:
-      '@jimp/core': 1.6.0
-      '@jimp/js-jpeg': 1.6.0
-      '@jimp/js-png': 1.6.0
-      '@jimp/plugin-blit': 1.6.0
-      '@jimp/types': 1.6.0
-      parse-bmfont-ascii: 1.0.6
-      parse-bmfont-binary: 1.0.6
-      parse-bmfont-xml: 1.1.6
-      simple-xml-to-json: 1.2.7
-      zod: 3.25.76
-
-  '@jimp/plugin-quantize@1.6.0':
-    dependencies:
-      image-q: 4.0.0
-      zod: 3.25.76
-
-  '@jimp/plugin-resize@1.6.0':
-    dependencies:
-      '@jimp/core': 1.6.0
-      '@jimp/types': 1.6.0
-      zod: 3.25.76
-
-  '@jimp/plugin-rotate@1.6.0':
-    dependencies:
-      '@jimp/core': 1.6.0
-      '@jimp/plugin-crop': 1.6.0
-      '@jimp/plugin-resize': 1.6.0
-      '@jimp/types': 1.6.0
-      '@jimp/utils': 1.6.0
-      zod: 3.25.76
-
-  '@jimp/plugin-threshold@1.6.0':
-    dependencies:
-      '@jimp/core': 1.6.0
-      '@jimp/plugin-color': 1.6.0
-      '@jimp/plugin-hash': 1.6.0
-      '@jimp/types': 1.6.0
-      '@jimp/utils': 1.6.0
-      zod: 3.25.76
-
-  '@jimp/types@1.6.0':
-    dependencies:
-      zod: 3.25.76
-
-  '@jimp/utils@1.6.0':
-    dependencies:
-      '@jimp/types': 1.6.0
-      tinycolor2: 1.6.0
-
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3371,7 +2905,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.1
+      '@tybys/wasm-util': 0.10.2
     optional: true
 
   '@octokit/auth-token@6.0.0': {}
@@ -3440,72 +2974,67 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
-  '@opencode-ai/plugin@1.14.22(@opentui/core@0.1.103(stage-js@1.0.2)(typescript@5.9.3)(web-tree-sitter@0.25.10))(@opentui/solid@0.1.103(solid-js@1.9.12)(stage-js@1.0.2)(typescript@5.9.3)(web-tree-sitter@0.25.10))':
+  '@opencode-ai/plugin@1.14.50(@opentui/core@0.2.10(typescript@5.9.3)(web-tree-sitter@0.25.10))(@opentui/solid@0.2.10(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))':
     dependencies:
-      '@opencode-ai/sdk': 1.14.22
-      effect: 4.0.0-beta.48
+      '@opencode-ai/sdk': 1.14.50
+      effect: 4.0.0-beta.65
       zod: 4.1.8
     optionalDependencies:
-      '@opentui/core': 0.1.103(stage-js@1.0.2)(typescript@5.9.3)(web-tree-sitter@0.25.10)
-      '@opentui/solid': 0.1.103(solid-js@1.9.12)(stage-js@1.0.2)(typescript@5.9.3)(web-tree-sitter@0.25.10)
+      '@opentui/core': 0.2.10(typescript@5.9.3)(web-tree-sitter@0.25.10)
+      '@opentui/solid': 0.2.10(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
 
-  '@opencode-ai/sdk@1.14.22':
+  '@opencode-ai/sdk@1.14.50':
     dependencies:
       cross-spawn: 7.0.6
 
-  '@opentui/core-darwin-arm64@0.1.103':
+  '@opentui/core-darwin-arm64@0.2.10':
     optional: true
 
-  '@opentui/core-darwin-x64@0.1.103':
+  '@opentui/core-darwin-x64@0.2.10':
     optional: true
 
-  '@opentui/core-linux-arm64@0.1.103':
+  '@opentui/core-linux-arm64@0.2.10':
     optional: true
 
-  '@opentui/core-linux-x64@0.1.103':
+  '@opentui/core-linux-x64@0.2.10':
     optional: true
 
-  '@opentui/core-win32-arm64@0.1.103':
+  '@opentui/core-win32-arm64@0.2.10':
     optional: true
 
-  '@opentui/core-win32-x64@0.1.103':
+  '@opentui/core-win32-x64@0.2.10':
     optional: true
 
-  '@opentui/core@0.1.103(stage-js@1.0.2)(typescript@5.9.3)(web-tree-sitter@0.25.10)':
+  '@opentui/core@0.2.10(typescript@5.9.3)(web-tree-sitter@0.25.10)':
     dependencies:
-      bun-ffi-structs: 0.1.2(typescript@5.9.3)
-      diff: 8.0.2
-      jimp: 1.6.0
+      bun-ffi-structs: 0.2.2(typescript@5.9.3)
+      diff: 9.0.0
       marked: 17.0.1
+      string-width: 7.2.0
+      strip-ansi: 7.1.2
       web-tree-sitter: 0.25.10
       yoga-layout: 3.2.1
     optionalDependencies:
-      '@dimforge/rapier2d-simd-compat': 0.17.3
-      '@opentui/core-darwin-arm64': 0.1.103
-      '@opentui/core-darwin-x64': 0.1.103
-      '@opentui/core-linux-arm64': 0.1.103
-      '@opentui/core-linux-x64': 0.1.103
-      '@opentui/core-win32-arm64': 0.1.103
-      '@opentui/core-win32-x64': 0.1.103
-      bun-webgpu: 0.1.5
-      planck: 1.5.0(stage-js@1.0.2)
-      three: 0.177.0
+      '@opentui/core-darwin-arm64': 0.2.10
+      '@opentui/core-darwin-x64': 0.2.10
+      '@opentui/core-linux-arm64': 0.2.10
+      '@opentui/core-linux-x64': 0.2.10
+      '@opentui/core-win32-arm64': 0.2.10
+      '@opentui/core-win32-x64': 0.2.10
     transitivePeerDependencies:
-      - stage-js
       - typescript
 
-  '@opentui/solid@0.1.103(solid-js@1.9.12)(stage-js@1.0.2)(typescript@5.9.3)(web-tree-sitter@0.25.10)':
+  '@opentui/solid@0.2.10(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/preset-typescript': 7.27.1(@babel/core@7.28.0)
-      '@opentui/core': 0.1.103(stage-js@1.0.2)(typescript@5.9.3)(web-tree-sitter@0.25.10)
+      '@opentui/core': 0.2.10(typescript@5.9.3)(web-tree-sitter@0.25.10)
       babel-plugin-module-resolver: 5.0.2
-      babel-preset-solid: 1.9.10(@babel/core@7.28.0)(solid-js@1.9.12)
+      babel-preset-solid: 1.9.12(@babel/core@7.28.0)(solid-js@1.9.12)
       entities: 7.0.1
       s-js: 0.4.9
       solid-js: 1.9.12
     transitivePeerDependencies:
-      - stage-js
       - supports-color
       - typescript
       - web-tree-sitter
@@ -3731,9 +3260,7 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@tokenizer/token@0.3.0': {}
-
-  '@tybys/wasm-util@0.10.1':
+  '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -3746,8 +3273,6 @@ snapshots:
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
-
-  '@types/node@16.9.1': {}
 
   '@types/node@22.19.17':
     dependencies:
@@ -3810,13 +3335,6 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@webgpu/types@0.1.69':
-    optional: true
-
-  abort-controller@3.0.0:
-    dependencies:
-      event-target-shim: 5.0.1
-
   acorn@8.16.0: {}
 
   agent-base@7.1.4: {}
@@ -3842,8 +3360,6 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
-  any-base@1.1.0: {}
-
   any-promise@1.3.0: {}
 
   argparse@2.0.1: {}
@@ -3859,8 +3375,6 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
       js-tokens: 10.0.0
-
-  await-to-js@3.0.0: {}
 
   babel-plugin-jsx-dom-expressions@0.40.6(@babel/core@7.28.0):
     dependencies:
@@ -3886,15 +3400,18 @@ snapshots:
     optionalDependencies:
       solid-js: 1.9.12
 
-  balanced-match@1.0.2: {}
+  babel-preset-solid@1.9.12(@babel/core@7.28.0)(solid-js@1.9.12):
+    dependencies:
+      '@babel/core': 7.28.0
+      babel-plugin-jsx-dom-expressions: 0.40.6(@babel/core@7.28.0)
+    optionalDependencies:
+      solid-js: 1.9.12
 
-  base64-js@1.5.1: {}
+  balanced-match@1.0.2: {}
 
   baseline-browser-mapping@2.10.21: {}
 
   before-after-hook@4.0.0: {}
-
-  bmp-ts@1.0.9: {}
 
   bottleneck@2.19.5: {}
 
@@ -3914,36 +3431,9 @@ snapshots:
       node-releases: 2.0.38
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
-  buffer@6.0.3:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-
-  bun-ffi-structs@0.1.2(typescript@5.9.3):
+  bun-ffi-structs@0.2.2(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
-
-  bun-webgpu-darwin-arm64@0.1.6:
-    optional: true
-
-  bun-webgpu-darwin-x64@0.1.6:
-    optional: true
-
-  bun-webgpu-linux-x64@0.1.6:
-    optional: true
-
-  bun-webgpu-win32-x64@0.1.6:
-    optional: true
-
-  bun-webgpu@0.1.5:
-    dependencies:
-      '@webgpu/types': 0.1.69
-    optionalDependencies:
-      bun-webgpu-darwin-arm64: 0.1.6
-      bun-webgpu-darwin-x64: 0.1.6
-      bun-webgpu-linux-x64: 0.1.6
-      bun-webgpu-win32-x64: 0.1.6
-    optional: true
 
   bundle-require@5.1.0(esbuild@0.27.7):
     dependencies:
@@ -4090,7 +3580,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  diff@8.0.2: {}
+  diff@9.0.0: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -4104,7 +3594,7 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  effect@4.0.0-beta.48:
+  effect@4.0.0-beta.65:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 4.7.0
@@ -4114,10 +3604,12 @@ snapshots:
       msgpackr: 1.11.10
       multipasta: 0.2.7
       toml: 4.1.1
-      uuid: 13.0.0
+      uuid: 13.0.2
       yaml: 2.8.3
 
   electron-to-chromium@1.5.344: {}
+
+  emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
 
@@ -4193,10 +3685,6 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
-  event-target-shim@5.0.1: {}
-
-  events@3.3.0: {}
-
   execa@8.0.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -4224,8 +3712,6 @@ snapshots:
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
 
-  exif-parser@0.1.12: {}
-
   expect-type@1.3.0: {}
 
   fast-check@4.7.0:
@@ -4245,12 +3731,6 @@ snapshots:
   figures@6.1.0:
     dependencies:
       is-unicode-supported: 2.1.0
-
-  file-type@16.5.4:
-    dependencies:
-      readable-web-to-node-stream: 3.0.4
-      strtok3: 6.3.0
-      token-types: 4.2.1
 
   fill-range@7.1.1:
     dependencies:
@@ -4307,6 +3787,8 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
+  get-east-asian-width@1.6.0: {}
+
   get-stream@6.0.1: {}
 
   get-stream@7.0.1: {}
@@ -4317,11 +3799,6 @@ snapshots:
     dependencies:
       '@sec-ant/readable-stream': 0.4.1
       is-stream: 4.0.1
-
-  gifwrap@0.10.1:
-    dependencies:
-      image-q: 4.0.0
-      omggif: 1.0.10
 
   git-log-parser@1.2.1:
     dependencies:
@@ -4393,12 +3870,6 @@ snapshots:
   human-signals@5.0.0: {}
 
   human-signals@8.0.1: {}
-
-  ieee754@1.2.1: {}
-
-  image-q@4.0.0:
-    dependencies:
-      '@types/node': 16.9.1
 
   import-fresh@3.3.1:
     dependencies:
@@ -4476,39 +3947,7 @@ snapshots:
 
   java-properties@1.0.2: {}
 
-  jimp@1.6.0:
-    dependencies:
-      '@jimp/core': 1.6.0
-      '@jimp/diff': 1.6.0
-      '@jimp/js-bmp': 1.6.0
-      '@jimp/js-gif': 1.6.0
-      '@jimp/js-jpeg': 1.6.0
-      '@jimp/js-png': 1.6.0
-      '@jimp/js-tiff': 1.6.0
-      '@jimp/plugin-blit': 1.6.0
-      '@jimp/plugin-blur': 1.6.0
-      '@jimp/plugin-circle': 1.6.0
-      '@jimp/plugin-color': 1.6.0
-      '@jimp/plugin-contain': 1.6.0
-      '@jimp/plugin-cover': 1.6.0
-      '@jimp/plugin-crop': 1.6.0
-      '@jimp/plugin-displace': 1.6.0
-      '@jimp/plugin-dither': 1.6.0
-      '@jimp/plugin-fisheye': 1.6.0
-      '@jimp/plugin-flip': 1.6.0
-      '@jimp/plugin-hash': 1.6.0
-      '@jimp/plugin-mask': 1.6.0
-      '@jimp/plugin-print': 1.6.0
-      '@jimp/plugin-quantize': 1.6.0
-      '@jimp/plugin-resize': 1.6.0
-      '@jimp/plugin-rotate': 1.6.0
-      '@jimp/plugin-threshold': 1.6.0
-      '@jimp/types': 1.6.0
-      '@jimp/utils': 1.6.0
-
   joycon@3.1.1: {}
-
-  jpeg-js@0.4.4: {}
 
   js-tokens@10.0.0: {}
 
@@ -4670,8 +4109,6 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
-  mime@3.0.0: {}
-
   mime@4.1.0: {}
 
   mimic-fn@4.0.0: {}
@@ -4719,7 +4156,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.12: {}
 
   neo-async@2.6.2: {}
 
@@ -4761,8 +4198,6 @@ snapshots:
   object-assign@4.1.1: {}
 
   obug@2.1.1: {}
-
-  omggif@1.0.10: {}
 
   onetime@6.0.0:
     dependencies:
@@ -4806,20 +4241,9 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  pako@1.0.11: {}
-
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
-
-  parse-bmfont-ascii@1.0.6: {}
-
-  parse-bmfont-binary@1.0.6: {}
-
-  parse-bmfont-xml@1.1.6:
-    dependencies:
-      xml-parse-from-string: 1.0.1
-      xml2js: 0.5.0
 
   parse-json@4.0.0:
     dependencies:
@@ -4870,8 +4294,6 @@ snapshots:
 
   pathe@2.0.3: {}
 
-  peek-readable@4.1.0: {}
-
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -4881,10 +4303,6 @@ snapshots:
   pify@3.0.0: {}
 
   pirates@4.0.7: {}
-
-  pixelmatch@5.3.0:
-    dependencies:
-      pngjs: 6.0.0
 
   pkg-conf@2.1.0:
     dependencies:
@@ -4901,25 +4319,16 @@ snapshots:
     dependencies:
       find-up: 3.0.0
 
-  planck@1.5.0(stage-js@1.0.2):
-    dependencies:
-      stage-js: 1.0.2
-    optional: true
-
-  pngjs@6.0.0: {}
-
-  pngjs@7.0.0: {}
-
-  postcss-load-config@6.0.1(postcss@8.5.12)(yaml@2.8.3):
+  postcss-load-config@6.0.1(postcss@8.5.14)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
-      postcss: 8.5.12
+      postcss: 8.5.14
       yaml: 2.8.3
 
-  postcss@8.5.12:
+  postcss@8.5.14:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -4928,8 +4337,6 @@ snapshots:
       parse-ms: 4.0.0
 
   process-nextick-args@2.0.1: {}
-
-  process@0.11.10: {}
 
   proto-list@1.2.4: {}
 
@@ -4965,18 +4372,6 @@ snapshots:
       safe-buffer: 5.1.2
       string_decoder: 1.1.1
       util-deprecate: 1.0.2
-
-  readable-stream@4.7.0:
-    dependencies:
-      abort-controller: 3.0.0
-      buffer: 6.0.3
-      events: 3.3.0
-      process: 0.11.10
-      string_decoder: 1.3.0
-
-  readable-web-to-node-stream@3.0.4:
-    dependencies:
-      readable-stream: 4.7.0
 
   readdirp@4.1.2: {}
 
@@ -5055,10 +4450,6 @@ snapshots:
 
   safe-buffer@5.1.2: {}
 
-  safe-buffer@5.2.1: {}
-
-  sax@1.6.0: {}
-
   semantic-release@24.2.9(typescript@5.9.3):
     dependencies:
       '@semantic-release/commit-analyzer': 13.0.1(semantic-release@24.2.9(typescript@5.9.3))
@@ -5126,8 +4517,6 @@ snapshots:
       figures: 2.0.0
       pkg-conf: 2.1.0
 
-  simple-xml-to-json@1.2.7: {}
-
   skin-tone@2.0.0:
     dependencies:
       unicode-emoji-modifier-base: 1.0.0
@@ -5166,9 +4555,6 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  stage-js@1.0.2:
-    optional: true
-
   std-env@4.1.0: {}
 
   stream-combiner2@1.1.1:
@@ -5182,17 +4568,23 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.1.2
+
   string_decoder@1.1.1:
     dependencies:
       safe-buffer: 5.1.2
 
-  string_decoder@1.3.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-ansi@7.1.2:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-bom@3.0.0: {}
 
@@ -5201,11 +4593,6 @@ snapshots:
   strip-final-newline@4.0.0: {}
 
   strip-json-comments@2.0.1: {}
-
-  strtok3@6.3.0:
-    dependencies:
-      '@tokenizer/token': 0.3.0
-      peek-readable: 4.1.0
 
   sucrase@3.35.1:
     dependencies:
@@ -5255,9 +4642,6 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
-  three@0.177.0:
-    optional: true
-
   through2@2.0.5:
     dependencies:
       readable-stream: 2.3.8
@@ -5268,8 +4652,6 @@ snapshots:
       convert-hrtime: 5.0.0
 
   tinybench@2.9.0: {}
-
-  tinycolor2@1.6.0: {}
 
   tinyexec@0.3.2: {}
 
@@ -5286,11 +4668,6 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  token-types@4.2.1:
-    dependencies:
-      '@tokenizer/token': 0.3.0
-      ieee754: 1.2.1
-
   toml@4.1.1: {}
 
   traverse@0.6.8: {}
@@ -5302,7 +4679,7 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  tsup@8.5.1(postcss@8.5.12)(typescript@5.9.3)(yaml@2.8.3):
+  tsup@8.5.1(postcss@8.5.14)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -5313,7 +4690,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.12)(yaml@2.8.3)
+      postcss-load-config: 6.0.1(postcss@8.5.14)(yaml@2.8.3)
       resolve-from: 5.0.0
       rollup: 4.60.2
       source-map: 0.7.6
@@ -5322,7 +4699,7 @@ snapshots:
       tinyglobby: 0.2.16
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.12
+      postcss: 8.5.14
       typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
@@ -5367,13 +4744,9 @@ snapshots:
 
   url-join@5.0.0: {}
 
-  utif2@4.1.0:
-    dependencies:
-      pako: 1.0.11
-
   util-deprecate@1.0.2: {}
 
-  uuid@13.0.0: {}
+  uuid@13.0.2: {}
 
   validate-npm-package-license@3.0.4:
     dependencies:
@@ -5384,7 +4757,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.12
+      postcss: 8.5.14
       rolldown: 1.0.0-rc.17
       tinyglobby: 0.2.16
     optionalDependencies:
@@ -5442,15 +4815,6 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  xml-parse-from-string@1.0.1: {}
-
-  xml2js@0.5.0:
-    dependencies:
-      sax: 1.6.0
-      xmlbuilder: 11.0.1
-
-  xmlbuilder@11.0.1: {}
-
   xtend@4.0.2: {}
 
   y18n@5.0.8: {}
@@ -5486,7 +4850,5 @@ snapshots:
   yoctocolors@2.1.2: {}
 
   yoga-layout@3.2.1: {}
-
-  zod@3.25.76: {}
 
   zod@4.1.8: {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import type { Plugin } from "@opencode-ai/plugin";
-import { writeFile } from "node:fs/promises";
 import { applySubagentEvent } from "./events.js";
 import { renderStatusLine } from "./render.js";
 import {
@@ -8,6 +7,7 @@ import {
   resolveStatePath,
   resolveTextPath,
   saveState,
+  saveStatusText,
   shouldPreserveStateOnStartup,
 } from "./state.js";
 
@@ -19,7 +19,7 @@ export const SubagentStatusline: Plugin = async () => {
     try {
       const emptyState = createEmptyState();
       await saveState(statePath, emptyState);
-      await writeFile(textPath, renderStatusLine(emptyState), "utf8");
+      await saveStatusText(textPath, renderStatusLine(emptyState));
     } catch {
       // Defensive by design: initialization failure should not crash OpenCode startup.
     }
@@ -34,7 +34,7 @@ export const SubagentStatusline: Plugin = async () => {
         if (changed) {
           await saveState(statePath, state);
           const line = renderStatusLine(state);
-          await writeFile(textPath, line, "utf8");
+          await saveStatusText(textPath, line);
         }
       } catch {
         // Defensive by design: plugin should never crash OpenCode on bad event shape.

--- a/src/logs.ts
+++ b/src/logs.ts
@@ -1,0 +1,19 @@
+import { readFileSync, statSync } from "node:fs";
+
+const MAX_SYNC_LOG_READ_BYTES = 1024 * 1024;
+
+function safeRead<T>(reader: () => T): T | undefined {
+  try {
+    return reader();
+  } catch {
+    return undefined;
+  }
+}
+
+export function readOpenCodeLogFileIfSmall(path: string): string | undefined {
+  const stats = safeRead(() => statSync(path));
+  if (!stats?.isFile() || stats.size > MAX_SYNC_LOG_READ_BYTES) {
+    return undefined;
+  }
+  return safeRead(() => readFileSync(path, "utf8"));
+}

--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readdir, stat, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
@@ -11,6 +11,7 @@ import {
   resolveStatePath,
   resolveTextPath,
   saveState,
+  saveStatusText,
   shouldPreserveStateOnStartup,
   upsertChildDetails,
   upsertRunningChild,
@@ -318,6 +319,29 @@ describe("state", () => {
       children: {},
       totalExecuted: 0,
     });
+  });
+
+  it("writes state and text snapshots atomically with owner-only file modes", async () => {
+    const harness = await createRuntimeHarness();
+    const state = createEmptyState();
+    state.children.ses_child = child();
+    state.totalExecuted = 1;
+    state.countedChildIDs.ses_child = true;
+
+    await saveState(harness.statePath, state);
+    await saveStatusText(join(harness.dir, "status.txt"), "subagents: 1");
+
+    expect(await loadState(harness.statePath)).toMatchObject({
+      totalExecuted: 1,
+    });
+    expect((await stat(harness.dir)).mode & 0o777).toBe(0o700);
+    expect((await stat(harness.statePath)).mode & 0o777).toBe(0o600);
+    expect((await stat(join(harness.dir, "status.txt"))).mode & 0o777).toBe(
+      0o600,
+    );
+    expect(
+      (await readdir(harness.dir)).some((file) => file.endsWith(".tmp")),
+    ).toBe(false);
   });
 
   it("does not add newly loaded tool wrappers while preserving historical tool counts", async () => {

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,5 +1,6 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
 import os from "node:os";
 
 export type ChildStatus = "running" | "done" | "error";
@@ -445,6 +446,8 @@ export function refreshDerivedFields(
 
 const STATUS_DIRNAME = "opencode-subagent-statusline";
 const STATUS_FILENAME = "state.json";
+const STATUS_DIR_MODE = 0o700;
+const STATUS_FILE_MODE = 0o600;
 
 function sanitizeInstanceName(input: string): string {
   return input.replace(/[^A-Za-z0-9._-]/g, "_");
@@ -529,7 +532,11 @@ export async function loadState(statePath: string): Promise<StatuslineState> {
         candidate.targetSessionID,
         id.startsWith("ses_") ? id : undefined,
       );
-      if (candidate.source === "subtask" && targetSessionID && state.countedChildIDs[id]) {
+      if (
+        candidate.source === "subtask" &&
+        targetSessionID &&
+        state.countedChildIDs[id]
+      ) {
         rekeyCountedExecution(state, id, targetSessionID);
       }
       const countIdentity = resolveExecutionCountIdentity(state, {
@@ -555,13 +562,43 @@ export async function loadState(statePath: string): Promise<StatuslineState> {
   }
 }
 
+async function writeLocalStatusFile(
+  path: string,
+  contents: string,
+): Promise<void> {
+  const directory = dirname(path);
+  await mkdir(directory, { recursive: true, mode: STATUS_DIR_MODE });
+
+  const tempPath = join(
+    directory,
+    `.${basename(path)}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`,
+  );
+
+  try {
+    await writeFile(tempPath, contents, {
+      encoding: "utf8",
+      mode: STATUS_FILE_MODE,
+    });
+    await rename(tempPath, path);
+  } catch (error) {
+    await rm(tempPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+export async function saveStatusText(
+  textPath: string,
+  contents: string,
+): Promise<void> {
+  await writeLocalStatusFile(textPath, contents);
+}
+
 export async function saveState(
   statePath: string,
   state: StatuslineState,
 ): Promise<void> {
   refreshDerivedFields(state);
-  await mkdir(dirname(statePath), { recursive: true });
-  await writeFile(statePath, JSON.stringify(state, null, 2), "utf8");
+  await writeLocalStatusFile(statePath, JSON.stringify(state, null, 2));
 }
 
 export function upsertRunningChild(

--- a/src/tui.test.ts
+++ b/src/tui.test.ts
@@ -1,4 +1,8 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { readOpenCodeLogFileIfSmall } from "./logs.js";
 import { registerSubagentCommands } from "./tui-commands.js";
 
 describe("registerSubagentCommands", () => {
@@ -67,5 +71,19 @@ describe("registerSubagentCommands", () => {
     expect(register).toHaveBeenCalledOnce();
     result();
     expect(dispose).toHaveBeenCalledOnce();
+  });
+});
+
+describe("readOpenCodeLogFileIfSmall", () => {
+  it("skips oversized OpenCode logs before reading them synchronously", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "subagent-statusline-logs-"));
+    const smallLog = join(dir, "small.log");
+    const hugeLog = join(dir, "huge.log");
+
+    await writeFile(smallLog, "small log", "utf8");
+    await writeFile(hugeLog, `${"x".repeat(1024 * 1024)}x`, "utf8");
+
+    expect(readOpenCodeLogFileIfSmall(smallLog)).toBe("small log");
+    expect(readOpenCodeLogFileIfSmall(hugeLog)).toBeUndefined();
   });
 });

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -6,17 +6,14 @@ import type {
   TuiSlotContext,
   TuiThemeCurrent,
 } from "@opencode-ai/plugin/tui";
-import type { BoxRenderable, KeyEvent, ScrollBoxRenderable } from "@opentui/core";
+import type {
+  BoxRenderable,
+  KeyEvent,
+  ScrollBoxRenderable,
+} from "@opentui/core";
 import { useKeyboard } from "@opentui/solid";
 import { execFileSync } from "node:child_process";
-import {
-  appendFileSync,
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  readdirSync,
-} from "node:fs";
-import { writeFile } from "node:fs/promises";
+import { appendFileSync, existsSync, mkdirSync, readdirSync } from "node:fs";
 import { createRequire } from "node:module";
 import os from "node:os";
 import { dirname, join } from "node:path";
@@ -31,6 +28,7 @@ import {
 } from "solid-js";
 import type { Accessor } from "solid-js";
 import { applySubagentEvent, extractChildDetails } from "./events.js";
+import { readOpenCodeLogFileIfSmall } from "./logs.js";
 import {
   byPriority,
   formatDuration,
@@ -59,6 +57,7 @@ import {
   resolveStatePath,
   resolveTextPath,
   saveState,
+  saveStatusText,
   upsertChildDetails,
   type ChildTokenState,
   type ChildSessionState,
@@ -151,7 +150,10 @@ function maxScrollTop(scrollbox: ScrollBoxRenderable): number {
   return Math.max(0, scrollbox.scrollHeight - scrollbox.viewport.height);
 }
 
-function clampedScrollTop(scrollbox: ScrollBoxRenderable, value: number): number {
+function clampedScrollTop(
+  scrollbox: ScrollBoxRenderable,
+  value: number,
+): number {
   return Math.max(0, Math.min(value, maxScrollTop(scrollbox)));
 }
 
@@ -362,7 +364,7 @@ function readDoneTokensFromOpenCodeLogs(
   const tokenPattern = /"tokens"\s*:\s*(\{[^\n]*?\})/g;
   let tokens: ChildTokenState | undefined;
   for (const file of files) {
-    const contents = safeRead(() => readFileSync(join(logDir, file), "utf8"));
+    const contents = readOpenCodeLogFileIfSmall(join(logDir, file));
     if (!contents || !contents.includes(sessionID)) continue;
 
     for (const line of contents.split("\n")) {
@@ -532,7 +534,7 @@ function persistStateSnapshot(
   void (async () => {
     try {
       await saveState(statePath, snapshot);
-      await writeFile(textPath, renderStatusLine(snapshot), "utf8");
+      await saveStatusText(textPath, renderStatusLine(snapshot));
     } catch {
       // Persistence is best-effort; TUI rendering must not fail because of files.
     }
@@ -847,7 +849,11 @@ function formatChildRowLine(input: {
       width - Math.max(0, detailChars - width),
     );
     if (labelBudget >= MIN_LABEL_WIDTH || meta.length === 0) {
-      const labelLines = wrapCompactText(title.label, Math.max(1, labelBudget), 2);
+      const labelLines = wrapCompactText(
+        title.label,
+        Math.max(1, labelBudget),
+        2,
+      );
       return {
         labelLines,
         secondaryLine: formatSecondaryLine(
@@ -864,7 +870,11 @@ function formatChildRowLine(input: {
   const labelLines = wrapCompactText(title.label, MIN_LABEL_WIDTH, 2);
   return {
     labelLines,
-    secondaryLine: formatSecondaryLine(labelLines[1], parenthetical, MIN_LABEL_WIDTH),
+    secondaryLine: formatSecondaryLine(
+      labelLines[1],
+      parenthetical,
+      MIN_LABEL_WIDTH,
+    ),
     elapsed,
     meta: "",
   };
@@ -886,13 +896,16 @@ function formatTerminalChildRowLine(input: {
   const labelSource = parenthetical
     ? `${title.label} ${parenthetical}`
     : title.label;
-  const context = contextVariants(input.child).find((variant) => variant.length > 0);
+  const context = contextVariants(input.child).find(
+    (variant) => variant.length > 0,
+  );
 
   return {
-    label: ellipsize(labelSource, Math.max(1, width - (input.reservedWidth ?? 0))),
-    meta: context
-      ? `${elapsed} ${context}`
-      : elapsed,
+    label: ellipsize(
+      labelSource,
+      Math.max(1, width - (input.reservedWidth ?? 0)),
+    ),
+    meta: context ? `${elapsed} ${context}` : elapsed,
   };
 }
 
@@ -962,7 +975,9 @@ function SidebarSubagents(props: {
   const visibleChildIDs = createMemo(() =>
     visibleChildren().map((child) => child.id),
   );
-  const [selectedChildID, setSelectedChildID] = createSignal<string | undefined>();
+  const [selectedChildID, setSelectedChildID] = createSignal<
+    string | undefined
+  >();
   const [listFocused, setListFocused] = createSignal(false);
   const [listFocusModeActive, setListFocusModeActive] = createSignal(false);
 
@@ -1080,7 +1095,10 @@ function SidebarSubagents(props: {
     if (rowTop < viewportTop) {
       scrollbox.scrollTop = clampedScrollTop(scrollbox, rowTop);
     } else if (rowBottom > viewportBottom) {
-      scrollbox.scrollTop = clampedScrollTop(scrollbox, rowBottom - listHeight());
+      scrollbox.scrollTop = clampedScrollTop(
+        scrollbox,
+        rowBottom - listHeight(),
+      );
     }
   };
 
@@ -1091,7 +1109,10 @@ function SidebarSubagents(props: {
     const fallbackIndex = delta > 0 ? 0 : ids.length - 1;
     const nextIndex = Math.max(
       0,
-      Math.min(ids.length - 1, currentIndex < 0 ? fallbackIndex : currentIndex + delta),
+      Math.min(
+        ids.length - 1,
+        currentIndex < 0 ? fallbackIndex : currentIndex + delta,
+      ),
     );
     setSelectedChildID(ids[nextIndex]);
   };
@@ -1108,7 +1129,9 @@ function SidebarSubagents(props: {
     const selected = visibleChildren().find(
       (child) => child.id === selectedChildID(),
     );
-    return selected ? resolveNavigableChildTargetSessionID(selected) : undefined;
+    return selected
+      ? resolveNavigableChildTargetSessionID(selected)
+      : undefined;
   };
 
   const activateSelectedChild = (): void => {
@@ -1287,7 +1310,9 @@ function SidebarSubagents(props: {
           fallback={
             <box flexDirection="column">
               <box flexDirection="row">
-                <text fg={selected() ? props.theme.accent : props.theme.textMuted}>
+                <text
+                  fg={selected() ? props.theme.accent : props.theme.textMuted}
+                >
                   {selected() ? "›" : " "}
                 </text>
                 <text fg={statusColor(status(), props.theme)}>
@@ -1311,7 +1336,9 @@ function SidebarSubagents(props: {
         >
           <box flexDirection="column">
             <box flexDirection="row">
-              <text fg={selected() ? props.theme.accent : props.theme.textMuted}>
+              <text
+                fg={selected() ? props.theme.accent : props.theme.textMuted}
+              >
                 {selected() ? "›" : " "}
               </text>
               <text fg={statusColor(status(), props.theme)}>
@@ -1422,7 +1449,9 @@ function HomeBottomStatus(props: {
 }) {
   const counts = createMemo(() => {
     const result = { running: 0, done: 0, error: 0 };
-    for (const child of visibleSubagentWorkItems(Object.values(props.state().children))) {
+    for (const child of visibleSubagentWorkItems(
+      Object.values(props.state().children),
+    )) {
       if (child.status === "running") result.running += 1;
       if (child.status === "done") result.done += 1;
       if (child.status === "error") result.error += 1;
@@ -1718,7 +1747,10 @@ function resolveRouteSessionID(api: TuiPluginApi): string | undefined {
     : undefined;
 }
 
-function resolveRunningChildAgeMillis(child: ChildSessionState, nowMs: number): {
+function resolveRunningChildAgeMillis(
+  child: ChildSessionState,
+  nowMs: number,
+): {
   startedMs: number;
   updatedMs: number;
 } {
@@ -1734,8 +1766,10 @@ function resolveReconcileTargetSessionID(
   state: StatuslineState,
   child: ChildSessionState,
 ): string | undefined {
-  return resolveChildTargetSessionID(child) ??
-    resolveSyntheticTargetFromHydratedState(state, child);
+  return (
+    resolveChildTargetSessionID(child) ??
+    resolveSyntheticTargetFromHydratedState(state, child)
+  );
 }
 
 function selectRunningReconcileCandidates(input: {
@@ -1835,7 +1869,9 @@ async function probeRunningEvidence(input: {
   );
   if (statusResp === undefined) probeFailed = true;
   const statuses = asRecord(statusResp?.data);
-  const statusFromClient = deriveSessionChildStatus(statuses?.[input.targetSessionID]);
+  const statusFromClient = deriveSessionChildStatus(
+    statuses?.[input.targetSessionID],
+  );
   if (statusFromClient === "done" || statusFromClient === "error") {
     return { status: statusFromClient, endedAt: new Date().toISOString() };
   }
@@ -2043,7 +2079,7 @@ function initializeTui(api: TuiPluginApi, disposeRoot: () => void): void {
 
   createEffect(() => {
     hydrateRetryTick();
-    const route = api.route.current;
+    void api.route.current;
     const routeSessionID = resolveRouteSessionID(api);
 
     if (previousRouteSessionID && previousRouteSessionID !== routeSessionID) {
@@ -2274,7 +2310,8 @@ function initializeTui(api: TuiPluginApi, disposeRoot: () => void): void {
                 staleThresholdMs: STALE_RUNNING_THRESHOLD_MS,
                 startedMs: candidate.startedMs,
                 updatedMs: candidate.updatedMs,
-                latestMessageActivityAtMs: parentSummary.latestMessageActivityAtMs,
+                latestMessageActivityAtMs:
+                  parentSummary.latestMessageActivityAtMs,
               });
             if (canSafelyFallbackByParentInactivity) {
               mutations.push({
@@ -2376,7 +2413,10 @@ function initializeTui(api: TuiPluginApi, disposeRoot: () => void): void {
         let changed = false;
 
         for (const mutation of mutations) {
-          if (mutation.reconcileWithoutTargetSessionID && mutation.targetSessionID.startsWith("ses_")) {
+          if (
+            mutation.reconcileWithoutTargetSessionID &&
+            mutation.targetSessionID.startsWith("ses_")
+          ) {
             changed =
               upsertChildDetails(next, mutation.childID, {
                 targetSessionID: mutation.targetSessionID,
@@ -2497,7 +2537,8 @@ function initializeTui(api: TuiPluginApi, disposeRoot: () => void): void {
       home_prompt(_ctx: TuiSlotContext, props: HomePromptProps) {
         const promptProps = {
           ...props,
-          ...(props.workspaceID === undefined && props.workspace_id !== undefined
+          ...(props.workspaceID === undefined &&
+          props.workspace_id !== undefined
             ? { workspaceID: props.workspace_id }
             : {}),
           ref: composePromptRef(props.ref),
@@ -2517,10 +2558,7 @@ function initializeTui(api: TuiPluginApi, disposeRoot: () => void): void {
           right:
             props.right ??
             (sessionID ? (
-              <api.ui.Slot
-                name="session_prompt_right"
-                session_id={sessionID}
-              />
+              <api.ui.Slot name="session_prompt_right" session_id={sessionID} />
             ) : undefined),
           ref: composePromptRef(props.ref),
         };

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -7,7 +7,7 @@ export default defineConfig([
       index: "src/index.ts",
     },
     format: ["esm"],
-    target: "node20",
+    target: "node22",
     dts: {
       entry: {
         index: "src/index.ts",
@@ -23,7 +23,7 @@ export default defineConfig([
       tui: "src/tui.tsx",
     },
     format: ["esm"],
-    target: "node20",
+    target: "node22",
     dts: {
       entry: {
         tui: "src/tui.tsx",


### PR DESCRIPTION
## Summary

- Harden npm supply-chain posture with pinned pnpm, script-disabled installs, audit/pack release gates, npm provenance configuration, and narrowed host peer ranges.
- Harden local persistence by writing state/status files atomically with owner-only modes and capping synchronous OpenCode log reads.
- Document security-hardening rationale, local privacy behavior, maintainer release controls, and developer npm hygiene.

Related issue: none — security hardening was requested directly and reviewed in-session before PR creation.

## Validation

- `pnpm audit --audit-level moderate`
- `pnpm audit --prod --audit-level moderate`
- `pnpm typecheck`
- `pnpm test`
- `pnpm pack --dry-run`
- Judgment Day dual review passed after fixes.

## Checklist

- [x] I used a Conventional Commit title (e.g. `fix: ...`, `feat: ...`, `docs: ...`)
- [x] I linked related issue(s), or explained why none are needed
- [x] I did not include secrets, credentials, or private data
- [x] I called out any security-sensitive behavior changes
- [x] I updated docs when behavior or usage changed
