### PR TITLE
fix(deps): allow OpenTUI 0.3 peers

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
   "license": "MIT",
   "peerDependencies": {
     "@opencode-ai/plugin": ">=1.14.50 <2",
-    "@opentui/core": ">=0.2.10 <0.3",
-    "@opentui/solid": ">=0.2.10 <0.3",
+    "@opentui/core": ">=0.2.10 <0.4",
+    "@opentui/solid": ">=0.2.10 <0.4",
     "solid-js": ">=1.9.12 <2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Closes #56
- Relaxes the OpenTUI peer dependency upper bound so npm can resolve OpenTUI 0.3.x with current OpenCode plugin installs.
- Keeps the change scoped to `@opentui/core` and `@opentui/solid` peer ranges.

## Validation

- [x] Dual blind compatibility review passed against `@opentui/core@0.3.0` and `@opentui/solid@0.3.0`.
- [x] Temporary-copy validation passed typecheck, build, and tests in both judge runs.
- [x] Verified final branch diff is only `package.json` peer dependency range changes.

## Checklist

- [x] I used a Conventional Commit title (e.g. `fix: ...`, `feat: ...`, `docs: ...`)
- [x] I linked related issue(s), or explained why none are needed
- [x] I did not include secrets, credentials, or private data
- [x] I called out any security-sensitive behavior changes
- [x] I updated docs when behavior or usage changed
