### PR TITLE
feat(i18n): add system locale detection and translation system

### DIFF
--- a/src/i18n.test.ts
+++ b/src/i18n.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { t, detectSystemLocale, type Locale } from "./i18n.js";
+
+describe("i18n", () => {
+  describe("detectSystemLocale", () => {
+    it("returns 'es' when LANG environment starts with 'es'", () => {
+      const original = process.env.LANG;
+      process.env.LANG = "es_ES.UTF-8";
+      const result = detectSystemLocale();
+      if (original !== undefined) process.env.LANG = original;
+      else delete process.env.LANG;
+      expect(result).toBe("es");
+    });
+
+    it("returns 'en' when LANG environment starts with 'en'", () => {
+      const original = process.env.LANG;
+      process.env.LANG = "en_US.UTF-8";
+      const result = detectSystemLocale();
+      if (original !== undefined) process.env.LANG = original;
+      else delete process.env.LANG;
+      expect(result).toBe("en");
+    });
+
+    it("returns 'en' as fallback for unsupported locales", () => {
+      const original = process.env.LANG;
+      process.env.LANG = "ja_JP.UTF-8";
+      const result = detectSystemLocale();
+      if (original !== undefined) process.env.LANG = original;
+      else delete process.env.LANG;
+      expect(result).toBe("en");
+    });
+
+    it("returns 'en' when no LANG env var is set", () => {
+      const original = process.env.LANG;
+      delete process.env.LANG;
+      const result = detectSystemLocale();
+      if (original !== undefined) process.env.LANG = original;
+      expect(result).toBe("en");
+    });
+  });
+
+  describe("t()", () => {
+    it("returns translated string for 'subagents' key", () => {
+      const result = t("subagents");
+      expect(typeof result).toBe("string");
+      expect(result.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,70 @@
+/**
+ * Internationalization module for subagent-statusline.
+ *
+ * Detects system locale and provides translation function.
+ * Extend translations dictionary as new UI strings are added.
+ */
+
+export type Locale = "es" | "en";
+
+const translations = {
+  es: {
+    subagents: "Subagentes",
+  },
+  en: {
+    subagents: "Subagents",
+  },
+} as const;
+
+export type TranslationKey = keyof (typeof translations)["en"];
+
+// Cached locale to avoid repeated Intl calls
+let _cachedLocale: Locale | null = null;
+
+/**
+ * Detects the system locale using Intl.DateTimeFormat.
+ * Falls back to English if the system locale is not supported.
+ */
+export function detectSystemLocale(): Locale {
+  // Check common environment variables as first fallback
+  const envLang =
+    process.env.LANG ??
+    process.env.LC_ALL ??
+    process.env.LANGUAGE ??
+    Intl.DateTimeFormat().resolvedOptions().locale;
+
+  const lang = envLang.toLowerCase();
+
+  if (lang.startsWith("es")) return "es";
+  return "en"; // default fallback
+}
+
+/**
+ * Returns the current locale, caching the result after first call.
+ */
+export function getLocale(): Locale {
+  if (_cachedLocale === null) {
+    _cachedLocale = detectSystemLocale();
+  }
+  return _cachedLocale;
+}
+
+/**
+ * Translates a key to the current locale.
+ * Throws if the key is not found in translations.
+ */
+export function t(key: TranslationKey): string {
+  const locale = getLocale();
+  const translation = translations[locale][key];
+
+  if (translation === undefined) {
+    // Fallback to English if key missing in current locale
+    const fallback = translations.en[key];
+    if (fallback === undefined) {
+      throw new Error(`Missing translation key: ${key}`);
+    }
+    return fallback;
+  }
+
+  return translation;
+}

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -68,6 +68,7 @@ import {
   type StatuslineState,
 } from "./state.js";
 import { registerSubagentCommands } from "./tui-commands.js";
+import { t } from "./i18n.js";
 
 const TUI_PLUGIN_ID = "subagent-statusline.tui";
 const ELAPSED_TICK_MS = 1000;
@@ -1410,7 +1411,7 @@ function SidebarSubagents(props: {
           fg={props.theme.text}
           selectable={false}
           onMouseDown={props.onToggleExpanded}
-        >{`${props.expanded() ? SIDEBAR_ARROW_EXPANDED : SIDEBAR_ARROW_COLLAPSED} Subagentes`}</text>
+        >{`${props.expanded() ? SIDEBAR_ARROW_EXPANDED : SIDEBAR_ARROW_COLLAPSED} ${t("subagents")}`}</text>
         <Show when={PLUGIN_VERSION}>
           {(version: Accessor<string>) => (
             <text


### PR DESCRIPTION
## Summary

Add internationalization support to the plugin, detecting system locale and displaying the correct language for UI strings.

## Changes

- **New file `src/i18n.ts`**: Translation system with:
  - `detectSystemLocale()` - detects locale from LANG/LC_ALL/LANGUAGE env vars or Intl API
  - `getLocale()` - cached locale getter
  - `t(key)` - translation function with English fallback

- **New file `src/i18n.test.ts`**: 5 tests covering locale detection and translation

- **Modified `src/tui.tsx`**: Replaced hardcoded Spanish 'Subagentes' with `t('subagents')`

## Motivation

Resolves #60 - The sidebar label was hardcoded in Spanish, showing incorrectly when the system locale is English.

## Testing

All 91 tests pass:

Test Files  7 passed (7)
     Tests  91 passed (91)

TypeScript compiles clean, build succeeds.