### PR TITLE
feat(tui): add completed history toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Restart OpenCode after editing the file.
 The TUI plugin adds a sidebar section that shows:
 
 - running subagents
-- completed subagents
+- recent completed subagents, with a manual completed history toggle for retained older completions
 - failed subagents
 - elapsed time
 - token/context usage when available
@@ -78,12 +78,19 @@ navigation shortcuts are handled only while the sidebar list is focused.
 | `j` / `ArrowDown`  | Move selection to the next visible subagent.                   |
 | `k` / `ArrowUp`    | Move selection to the previous visible subagent.               |
 | `Enter`            | Open the selected subagent session.                            |
+| `c`                | Toggle retained completed history in the sidebar.              |
 | `h` / `ArrowLeft`  | Collapse the subagent section.                                 |
 | `l` / `ArrowRight` | Expand the subagent section.                                   |
 | `Esc`              | Leave list focus mode and return to the prompt.                |
 
 Opening a selected session is a no-op when there is no visible or navigable
 subagent.
+
+Click `Σ` in the sidebar aggregate row to toggle completed history with the
+mouse. The toggle is not persisted; it resets when OpenCode or the plugin is
+reloaded. Completed history is bounded retained history, not a full database:
+terminal rows are kept for up to 3 days with a 1,500-row cap, and rows already
+pruned from state are not restored.
 
 When a child session is opened from the sidebar, returning with OpenCode `Up`
 (`session_parent`) moves keyboard focus to the parent prompt so you can type

--- a/docs/en/02-installation-and-usage.md
+++ b/docs/en/02-installation-and-usage.md
@@ -113,6 +113,7 @@ The sidebar supports keyboard navigation while the list is focused.
 | `j` / `ArrowDown`  | Move selection to the next visible subagent.              |
 | `k` / `ArrowUp`    | Move selection to the previous subagent.                  |
 | `Enter`            | Open the selected session, if a navigable session exists. |
+| `c`                | Toggle completed history for retained `done` rows.        |
 | `h` / `ArrowLeft`  | Collapse the section.                                     |
 | `l` / `ArrowRight` | Expand the section.                                       |
 | `Esc`              | Leave list focus mode and return to the prompt.           |
@@ -122,6 +123,7 @@ You can also use OpenCode's command palette:
 ```txt
 Subagents: Focus sidebar list
 Subagents: Toggle sidebar section
+Subagents: Toggle completed history
 ```
 
 ## When a row can be opened

--- a/docs/en/03-architecture.md
+++ b/docs/en/03-architecture.md
@@ -207,6 +207,7 @@ Unknown statuses are treated as inconclusive instead of guessed.
 | --- | --- |
 | `Subagents: Toggle sidebar section` | Enable or disable the subagent section. |
 | `Subagents: Focus sidebar list` | Move focus to the subagent list. |
+| `Subagents: Toggle completed history` | Toggle retained completed rows in the sidebar. |
 
 Main shortcut:
 

--- a/docs/en/05-state-model-and-counters.md
+++ b/docs/en/05-state-model-and-counters.md
@@ -251,7 +251,9 @@ State refresh recalculates fields such as:
 | `updatedAt` | Latest known update. |
 | tokens/context | Evidence from events, TUI state, SQLite, or logs. |
 
-Old terminal children may be pruned to avoid unbounded growth. Pruning rows must not reduce `totalExecuted`.
+Old terminal children may be pruned to avoid unbounded growth. Terminal rows are
+retained for up to 3 days with a 1,500-row cap. Pruning rows must not reduce
+`totalExecuted`.
 
 ## Main mutation helpers
 

--- a/docs/en/06-rendering-and-deduplication.md
+++ b/docs/en/06-rendering-and-deduplication.md
@@ -160,6 +160,11 @@ General behavior:
 
 This keeps the sidebar useful instead of turning it into a long history.
 
+The sidebar can temporarily relax the `done` filters through completed history.
+When completed history is enabled, stale `done` rows and unrelated `done` rows
+hidden during active work become visible again after the normal collapse/dedupe
+step. Text statusline output and the home summary keep the default filtering.
+
 ## Visibility vs pruning
 
 Hiding a row during render is not the same as deleting it from state.
@@ -167,9 +172,13 @@ Hiding a row during render is not the same as deleting it from state.
 Two layers exist:
 
 1. **Visibility filtering** in `src/render.ts`.
-2. **State pruning** in `src/state.ts`.
+2. **State pruning** in `src/state.ts`, which keeps terminal rows for up to 3
+   days with a 1,500-row cap.
 
 Neither should reduce `totalExecuted`.
+
+Completed history only displays retained rows. It does not restore rows that
+state pruning already removed or past sessions that OpenCode APIs do not return.
 
 ## Text rendering
 
@@ -239,6 +248,9 @@ Important distinction:
 | `tool:prt_task` + `ses_child` | One real session row. |
 | `subtask:prt_1` + `ses_child` | One enriched subtask row. |
 | Old `done` plus active work | Active work visible; old done hidden. |
+
+With completed history enabled in the sidebar, the old `done` row in the final
+case is visible again if it is still retained in state.
 
 ## When not collapsing is correct
 

--- a/docs/en/07-tui-interface.md
+++ b/docs/en/07-tui-interface.md
@@ -104,6 +104,7 @@ When the list is focused, navigation shortcuts apply to the list. Otherwise, the
 | --- | --- |
 | `Subagents: Focus sidebar list` | Focus the subagent list. |
 | `Subagents: Toggle sidebar section` | Enable or disable the section. |
+| `Subagents: Toggle completed history` | Toggle retained completed rows in the sidebar. |
 
 Internally, the plugin registers both APIs when available: `keymap.registerLayer`
 keeps `Alt+B` dispatch fast, and `command.register` keeps commands visible in the
@@ -129,7 +130,8 @@ keeping list focus.
 
 The section can be expanded/collapsed and enabled/disabled.
 
-Clicking `Σ` in the sidebar aggregate row toggles completed history. This shows
+Clicking `Σ`, pressing `c` while the list is focused, or running
+`Subagents: Toggle completed history` toggles completed history. This shows
 retained stale `done` rows and retained `done` rows that are unrelated to active
 work. The toggle is transient and is not stored in `api.kv`.
 

--- a/docs/en/07-tui-interface.md
+++ b/docs/en/07-tui-interface.md
@@ -91,6 +91,7 @@ When the list is focused, navigation shortcuts apply to the list. Otherwise, the
 | `k` | Select the previous subagent. |
 | `ArrowUp` | Select the previous subagent. |
 | `Enter` | Open the selected session if navigable. |
+| `c` | Toggle completed history for retained `done` rows. |
 | `h` | Collapse the section. |
 | `ArrowLeft` | Collapse the section. |
 | `l` | Expand the section. |
@@ -128,6 +129,10 @@ keeping list focus.
 
 The section can be expanded/collapsed and enabled/disabled.
 
+Clicking `Σ` in the sidebar aggregate row toggles completed history. This shows
+retained stale `done` rows and retained `done` rows that are unrelated to active
+work. The toggle is transient and is not stored in `api.kv`.
+
 Preferences are stored through OpenCode `api.kv`:
 
 | Preference | Use |
@@ -136,6 +141,10 @@ Preferences are stored through OpenCode `api.kv`:
 | `subagents.sidebar.enabled` | Remembers whether the section is enabled. |
 
 These preferences belong to the TUI environment, not the runtime plugin's `state.json`.
+
+Completed history is bounded by state retention: terminal rows are retained for
+up to 3 days with a 1,500-row cap. Rows already pruned from state are not
+restored.
 
 ## Scroll and selection
 
@@ -230,9 +239,10 @@ For full visual changes, run a manual OpenCode smoke test.
 4. Run a delegation/subagent.
 5. Verify it appears in the sidebar.
 6. Test `Alt+B`.
-7. Test `j/k`, arrows, and `Esc`.
-8. If a row is navigable, test `Enter`.
-9. Confirm recent completions appear without polluting the view indefinitely.
+7. Test `j/k`, arrows, `c`, and `Esc`.
+8. Click `Σ` and verify completed history toggles.
+9. If a row is navigable, test `Enter`.
+10. Confirm recent completions appear without polluting the default view indefinitely.
 
 ## Related files
 

--- a/docs/es/02-instalacion-y-uso.md
+++ b/docs/es/02-instalacion-y-uso.md
@@ -113,6 +113,7 @@ La sidebar soporta navegación por teclado cuando la lista está enfocada.
 | `j` / `ArrowDown`  | Mueve la selección al siguiente subagente visible.        |
 | `k` / `ArrowUp`    | Mueve la selección al subagente anterior.                 |
 | `Enter`            | Abre la sesión seleccionada, si hay una sesión navegable. |
+| `c`                | Alterna completed history para filas `done` retenidas.    |
 | `h` / `ArrowLeft`  | Colapsa la sección.                                       |
 | `l` / `ArrowRight` | Expande la sección.                                       |
 | `Esc`              | Sale del modo foco y vuelve al prompt.                    |
@@ -122,6 +123,7 @@ También podés usar la command palette de OpenCode:
 ```txt
 Subagents: Focus sidebar list
 Subagents: Toggle sidebar section
+Subagents: Toggle completed history
 ```
 
 ## Cuándo una fila se puede abrir

--- a/docs/es/03-arquitectura.md
+++ b/docs/es/03-arquitectura.md
@@ -262,6 +262,7 @@ Comandos principales:
 | ----------------------------------- | -------------------------------------------- |
 | `Subagents: Toggle sidebar section` | Activa o desactiva la sección de subagentes. |
 | `Subagents: Focus sidebar list`     | Mueve el foco a la lista de subagentes.      |
+| `Subagents: Toggle completed history` | Alterna filas completadas retenidas en la sidebar. |
 
 Atajo principal:
 

--- a/docs/es/05-modelo-de-estado-y-contadores.md
+++ b/docs/es/05-modelo-de-estado-y-contadores.md
@@ -277,7 +277,8 @@ También poda filas terminales viejas para evitar crecimiento indefinido.
 
 ## Poda de hijos terminales
 
-El estado conserva hijos `done` o `error` durante un tiempo limitado.
+El estado conserva hijos `done` o `error` durante un tiempo limitado: hasta 3
+días, con un límite de 1.500 filas terminales.
 
 El objetivo:
 

--- a/docs/es/06-renderizado-y-deduplicacion.md
+++ b/docs/es/06-renderizado-y-deduplicacion.md
@@ -178,6 +178,12 @@ Reglas generales:
 
 Esto mantiene la sidebar útil y evita que se convierta en un historial largo.
 
+La sidebar puede relajar temporalmente los filtros de `done` con completed
+history. Cuando completed history está activo, las filas `done` viejas y las
+filas `done` no relacionadas con el trabajo activo vuelven a mostrarse después
+del collapse/dedupe normal. El statusline textual y el resumen de home conservan
+el filtrado por defecto.
+
 ## Relación con poda de estado
 
 Ocultar una fila en render no significa borrarla inmediatamente del estado.
@@ -185,11 +191,15 @@ Ocultar una fila en render no significa borrarla inmediatamente del estado.
 Hay dos capas distintas:
 
 1. **Filtro de visibilidad** en `src/render.ts`.
-2. **Poda de estado** en `src/state.ts`.
+2. **Poda de estado** en `src/state.ts`, que conserva filas terminales hasta 3
+   días con un límite de 1.500 filas.
 
 El filtro decide qué ve el usuario ahora. La poda evita que el estado crezca indefinidamente.
 
 Ninguna de las dos debería reducir `totalExecuted`.
+
+Completed history solo muestra filas retenidas. No restaura filas que la poda de
+estado ya eliminó ni sesiones pasadas que las APIs de OpenCode no devuelven.
 
 ## Render textual
 
@@ -323,6 +333,9 @@ Total:
 ```
 
 La finalización vieja se oculta para no ensuciar la vista.
+
+Con completed history activo en la sidebar, esa fila `done` vieja vuelve a ser
+visible si todavía está retenida en el estado.
 
 ## Casos donde no colapsar es correcto
 

--- a/docs/es/07-interfaz-tui.md
+++ b/docs/es/07-interfaz-tui.md
@@ -113,6 +113,7 @@ El plugin registra comandos para la command palette de OpenCode.
 | ----------------------------------- | ------------------------------ |
 | `Subagents: Focus sidebar list`     | Enfoca la lista de subagentes. |
 | `Subagents: Toggle sidebar section` | Activa o desactiva la sección. |
+| `Subagents: Toggle completed history` | Alterna filas completadas retenidas en la sidebar. |
 
 Internamente, el plugin registra ambas APIs cuando están disponibles:
 `keymap.registerLayer` mantiene el atajo `Alt+B`, y `command.register` mantiene
@@ -137,10 +138,10 @@ Esto es intencional: navegar requiere una sesión real de OpenCode.
 
 La sección puede expandirse o colapsarse.
 
-Hacer click en `Σ` dentro de la fila agregada de la sidebar alterna completed
-history. Esto muestra filas `done` viejas retenidas y filas `done` retenidas que
-no están relacionadas con el trabajo activo. El toggle es transitorio y no se
-guarda en `api.kv`.
+Hacer click en `Σ`, presionar `c` con la lista enfocada o ejecutar
+`Subagents: Toggle completed history` alterna completed history. Esto muestra
+filas `done` viejas retenidas y filas `done` retenidas que no están relacionadas
+con el trabajo activo. El toggle es transitorio y no se guarda en `api.kv`.
 
 El plugin guarda preferencias en `api.kv` de OpenCode:
 

--- a/docs/es/07-interfaz-tui.md
+++ b/docs/es/07-interfaz-tui.md
@@ -98,6 +98,7 @@ Cuando la lista está enfocada, los atajos de navegación se aplican a la lista.
 | `k`          | Selecciona el subagente anterior.            |
 | `ArrowUp`    | Selecciona el subagente anterior.            |
 | `Enter`      | Abre la sesión seleccionada si es navegable. |
+| `c`          | Alterna completed history para filas `done` retenidas. |
 | `h`          | Colapsa la sección.                          |
 | `ArrowLeft`  | Colapsa la sección.                          |
 | `l`          | Expande la sección.                          |
@@ -136,6 +137,11 @@ Esto es intencional: navegar requiere una sesión real de OpenCode.
 
 La sección puede expandirse o colapsarse.
 
+Hacer click en `Σ` dentro de la fila agregada de la sidebar alterna completed
+history. Esto muestra filas `done` viejas retenidas y filas `done` retenidas que
+no están relacionadas con el trabajo activo. El toggle es transitorio y no se
+guarda en `api.kv`.
+
 El plugin guarda preferencias en `api.kv` de OpenCode:
 
 | Preferencia                  | Uso                                     |
@@ -144,6 +150,10 @@ El plugin guarda preferencias en `api.kv` de OpenCode:
 | `subagents.sidebar.enabled`  | Recuerda si la sección está habilitada. |
 
 Estas preferencias pertenecen al entorno TUI de OpenCode, no al archivo `state.json` del runtime plugin.
+
+Completed history está limitado por la retención de estado: las filas terminales
+se conservan hasta 3 días con un límite de 1.500 filas. Las filas ya podadas del
+estado no se restauran.
 
 ## Scroll y selección
 
@@ -250,9 +260,10 @@ Para validar la TUI después de cambios:
 4. Ejecutar una delegación/subagente.
 5. Verificar que aparece en la sidebar.
 6. Probar `Alt+B`.
-7. Probar `j/k`, flechas y `Esc`.
-8. Si hay sesión navegable, probar `Enter`.
-9. Confirmar que completions recientes aparecen y luego no ensucian la vista.
+7. Probar `j/k`, flechas, `c` y `Esc`.
+8. Hacer click en `Σ` y verificar que completed history alterna.
+9. Si hay sesión navegable, probar `Enter`.
+10. Confirmar que completions recientes aparecen y luego no ensucian la vista por defecto.
 
 ## Archivos relacionados
 

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -95,6 +95,102 @@ describe("render", () => {
     ]);
   });
 
+  it("keeps multiple generic wrappers visible when they are the only representation", () => {
+    const children: ChildSessionState[] = [
+      child({
+        id: "tool:ping-1",
+        title: "task",
+        source: "tool",
+        messageID: "msg_ping_1",
+        targetSessionID: "ses_ping_1",
+      }),
+      child({
+        id: "ses_ping_1",
+        title: "Ping subagent one",
+        source: "session",
+        messageID: "msg_ping_1",
+        targetSessionID: "ses_ping_1",
+        status: "done",
+        color: "green",
+        endedAt: "2026-04-30T10:02:00.000Z",
+      }),
+      child({
+        id: "tool:ping-2",
+        title: "delegate",
+        source: "tool",
+        messageID: "msg_ping_2",
+        targetSessionID: "ses_ping_2",
+      }),
+      child({
+        id: "ses_ping_2",
+        title: "Ping subagent two",
+        source: "session",
+        messageID: "msg_ping_2",
+        targetSessionID: "ses_ping_2",
+        status: "done",
+        color: "green",
+        endedAt: "2026-04-30T10:03:00.000Z",
+      }),
+    ];
+
+    const collapsed = collapseSubagentWorkItems(children);
+
+    expect(collapsed.map((item) => item.id)).toEqual([
+      "tool:ping-1",
+      "tool:ping-2",
+    ]);
+    expect(collapsed).toEqual([
+      expect.objectContaining({ status: "done", targetSessionID: "ses_ping_1" }),
+      expect.objectContaining({ status: "done", targetSessionID: "ses_ping_2" }),
+    ]);
+  });
+
+  it("shows retained generic completed rows when completed history is enabled", () => {
+    const now = Date.parse("2026-04-30T10:20:00.000Z");
+    const children: ChildSessionState[] = [
+      child({
+        id: "tool:old-ping-1",
+        title: "task",
+        source: "tool",
+        messageID: "msg_old_ping_1",
+        targetSessionID: "ses_old_ping_1",
+      }),
+      child({
+        id: "ses_old_ping_1",
+        title: "Old ping one",
+        source: "session",
+        messageID: "msg_old_ping_1",
+        targetSessionID: "ses_old_ping_1",
+        status: "done",
+        color: "green",
+        endedAt: "2026-04-30T10:02:00.000Z",
+      }),
+      child({
+        id: "tool:old-ping-2",
+        title: "delegate",
+        source: "tool",
+        messageID: "msg_old_ping_2",
+        targetSessionID: "ses_old_ping_2",
+      }),
+      child({
+        id: "ses_old_ping_2",
+        title: "Old ping two",
+        source: "session",
+        messageID: "msg_old_ping_2",
+        targetSessionID: "ses_old_ping_2",
+        status: "done",
+        color: "green",
+        endedAt: "2026-04-30T10:03:00.000Z",
+      }),
+    ];
+
+    expect(
+      visibleSubagentWorkItems(children, now, {
+        showCompletedHistory: true,
+      }).map((item) => item.id),
+    ).toEqual(["tool:old-ping-1", "tool:old-ping-2"]);
+  });
+
   it("keeps one grouped row and avoids duplicate wrappers", () => {
     const children: ChildSessionState[] = [
       child({

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -155,6 +155,22 @@ describe("render", () => {
     ).toEqual(["done_recent"]);
   });
 
+  it("shows stale done items when completed history is enabled", () => {
+    const now = Date.parse("2026-04-30T10:20:00.000Z");
+    const hiddenDone = child({
+      id: "done_old",
+      status: "done",
+      color: "green",
+      endedAt: "2026-04-30T10:00:00.000Z",
+    });
+
+    expect(
+      visibleSubagentWorkItems([hiddenDone], now, {
+        showCompletedHistory: true,
+      }).map((item) => item.id),
+    ).toEqual(["done_old"]);
+  });
+
   it("keeps active running work visible and deprioritizes unrelated done rows", () => {
     const nowMs = Date.parse("2026-04-30T12:15:00.000Z");
     const children: ChildSessionState[] = [
@@ -196,6 +212,49 @@ describe("render", () => {
     expect(visible.some((item) => item.id === "subtask:historical")).toBe(
       false,
     );
+  });
+
+  it("shows unrelated done rows during active work when completed history is enabled", () => {
+    const nowMs = Date.parse("2026-04-30T12:15:00.000Z");
+    const children: ChildSessionState[] = [
+      child({
+        id: "subtask:active",
+        title: "Long running active work",
+        source: "subtask",
+        messageID: "msg_active",
+        status: "running",
+      }),
+      child({
+        id: "subtask:active-done",
+        title: "Recent completion in active thread",
+        source: "subtask",
+        messageID: "msg_active",
+        status: "done",
+        color: "green",
+        endedAt: "2026-04-30T12:14:00.000Z",
+        updatedAt: "2026-04-30T12:14:00.000Z",
+      }),
+      child({
+        id: "subtask:historical",
+        title: "Historical completion",
+        source: "subtask",
+        messageID: "msg_old",
+        status: "done",
+        color: "green",
+        endedAt: "2026-04-30T12:14:00.000Z",
+        updatedAt: "2026-04-30T12:14:00.000Z",
+      }),
+    ];
+
+    const visible = visibleSubagentWorkItems(children, nowMs, {
+      showCompletedHistory: true,
+    });
+
+    expect(visible.map((item) => item.id)).toEqual([
+      "subtask:active",
+      "subtask:active-done",
+      "subtask:historical",
+    ]);
   });
 
   it("sorts ties by id for stable priority", () => {

--- a/src/render.ts
+++ b/src/render.ts
@@ -149,6 +149,10 @@ export function byPriority(a: ChildSessionState, b: ChildSessionState): number {
 
 const RECENT_DONE_VISIBLE_MS = 10 * 60 * 1000;
 
+interface VisibleSubagentWorkItemsOptions {
+  showCompletedHistory?: boolean;
+}
+
 function normalizeWorkItemTitle(value: string): string {
   return value
     .toLowerCase()
@@ -341,10 +345,12 @@ export function isVisibleWorkItem(
 export function visibleSubagentWorkItems(
   children: ChildSessionState[],
   nowMs = Date.now(),
+  options: VisibleSubagentWorkItemsOptions = {},
 ): ChildSessionState[] {
-  const visible = collapseSubagentWorkItems(children).filter((child) =>
-    isVisibleWorkItem(child, nowMs),
-  );
+  const collapsed = collapseSubagentWorkItems(children);
+  if (options.showCompletedHistory) return collapsed;
+
+  const visible = collapsed.filter((child) => isVisibleWorkItem(child, nowMs));
   const hasRunning = visible.some((child) => child.status === "running");
   const activeMessageIDs = new Set(
     visible

--- a/src/render.ts
+++ b/src/render.ts
@@ -239,8 +239,6 @@ export function collapseSubagentWorkItems(
   const syntheticChildren: ChildSessionState[] = [];
   const syntheticByParentID = new Map<string, ChildSessionState[]>();
   const sessionCandidatesByParentID = new Map<string, ChildSessionState[]>();
-  const hiddenTargetSessionIDs = new Set<string>();
-  const hiddenMessageKeys = new Set<string>();
 
   for (const child of children) {
     const isSynthetic = child.source === "tool" || child.source === "subtask";
@@ -253,12 +251,6 @@ export function collapseSubagentWorkItems(
         syntheticByParentID.set(child.parentID, [child]);
       }
 
-      if (child.targetSessionID) {
-        hiddenTargetSessionIDs.add(child.targetSessionID);
-      }
-      if (child.messageID) {
-        hiddenMessageKeys.add(messageKey(child.parentID, child.messageID));
-      }
     }
 
     if (child.source === "session" || child.id.startsWith("ses_")) {
@@ -272,7 +264,6 @@ export function collapseSubagentWorkItems(
   }
 
   const sessionBySyntheticID = new Map<string, ChildSessionState>();
-  const hiddenMatchedSessionIDs = new Set<string>();
   const hiddenSyntheticToolIDs = new Set<string>();
 
   for (const synthetic of syntheticChildren) {
@@ -284,9 +275,6 @@ export function collapseSubagentWorkItems(
         continue;
       }
       bestSession = betterPriority(bestSession, candidate);
-      if (candidate.source === "session") {
-        hiddenMatchedSessionIDs.add(candidate.id);
-      }
     }
     if (bestSession) {
       sessionBySyntheticID.set(synthetic.id, bestSession);
@@ -297,7 +285,9 @@ export function collapseSubagentWorkItems(
     for (const child of siblings) {
       if (child.source !== "tool") continue;
       if (isGenericToolWrapper(child)) {
-        if (siblings.length > 1) hiddenSyntheticToolIDs.add(child.id);
+        if (siblings.some((sibling) => !isGenericToolWrapper(sibling))) {
+          hiddenSyntheticToolIDs.add(child.id);
+        }
         continue;
       }
 
@@ -308,6 +298,23 @@ export function collapseSubagentWorkItems(
           break;
         }
       }
+    }
+  }
+
+  const hiddenTargetSessionIDs = new Set<string>();
+  const hiddenMessageKeys = new Set<string>();
+  const hiddenMatchedSessionIDs = new Set<string>();
+  for (const synthetic of syntheticChildren) {
+    if (hiddenSyntheticToolIDs.has(synthetic.id)) continue;
+    if (synthetic.targetSessionID) {
+      hiddenTargetSessionIDs.add(synthetic.targetSessionID);
+    }
+    if (synthetic.messageID) {
+      hiddenMessageKeys.add(messageKey(synthetic.parentID, synthetic.messageID));
+    }
+    const matchedSession = sessionBySyntheticID.get(synthetic.id);
+    if (matchedSession?.source === "session") {
+      hiddenMatchedSessionIDs.add(matchedSession.id);
     }
   }
 

--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -269,15 +269,15 @@ describe("state", () => {
       id: "oldDone",
       status: "done",
       color: "green",
-      endedAt: "2026-04-30T08:00:00.000Z",
-      updatedAt: "2026-04-30T08:00:00.000Z",
+      endedAt: "2026-04-26T08:00:00.000Z",
+      updatedAt: "2026-04-26T08:00:00.000Z",
     });
     state.children.recentDone = child({
       id: "recentDone",
       status: "done",
       color: "green",
-      endedAt: "2026-04-30T09:30:00.000Z",
-      updatedAt: "2026-04-30T09:30:00.000Z",
+      endedAt: "2026-04-28T09:30:00.000Z",
+      updatedAt: "2026-04-28T09:30:00.000Z",
     });
 
     expect(

--- a/src/state.ts
+++ b/src/state.ts
@@ -43,8 +43,8 @@ export interface StatusCounts {
   error: number;
 }
 
-const TERMINAL_CHILD_TTL_MS = 60 * 60 * 1000;
-const MAX_TERMINAL_CHILDREN = 500;
+const TERMINAL_CHILD_TTL_MS = 3 * 24 * 60 * 60 * 1000;
+const MAX_TERMINAL_CHILDREN = 1_500;
 
 function statusColor(status: ChildStatus): ChildSessionState["color"] {
   if (status === "done") return "green";

--- a/src/tui-commands.ts
+++ b/src/tui-commands.ts
@@ -45,10 +45,13 @@ type RegisterSubagentCommandsInput = {
   sectionEnabled: () => boolean;
   toggleSection: (enabled: boolean) => void;
   focusSidebarList: () => void;
+  toggleCompletedHistory: () => void;
 };
 
 const TOGGLE_SECTION_COMMAND = "subagent-statusline.toggle-sidebar-section";
 const FOCUS_SIDEBAR_LIST_COMMAND = "subagent-statusline.focus-sidebar-list";
+const TOGGLE_COMPLETED_HISTORY_COMMAND =
+  "subagent-statusline.toggle-completed-history";
 const COMMAND_CATEGORY = "Subagents";
 
 type SharedCommandMetadata = {
@@ -61,6 +64,7 @@ type SharedCommandMetadata = {
 const SHARED_COMMAND_METADATA: {
   toggle: SharedCommandMetadata;
   focus: SharedCommandMetadata;
+  toggleCompletedHistory: SharedCommandMetadata;
 } = {
   toggle: {
     id: TOGGLE_SECTION_COMMAND,
@@ -72,6 +76,13 @@ const SHARED_COMMAND_METADATA: {
     id: FOCUS_SIDEBAR_LIST_COMMAND,
     title: "Subagents: Focus sidebar list",
     description: "Focus the subagent sidebar list for keyboard navigation",
+    category: COMMAND_CATEGORY,
+  },
+  toggleCompletedHistory: {
+    id: TOGGLE_COMPLETED_HISTORY_COMMAND,
+    title: "Subagents: Toggle completed history",
+    description:
+      "Toggle retained completed rows in the subagent sidebar. Shortcut: c while the sidebar list is focused.",
     category: COMMAND_CATEGORY,
   },
 };
@@ -103,35 +114,44 @@ export function registerSubagentCommands({
   sectionEnabled,
   toggleSection,
   focusSidebarList,
+  toggleCompletedHistory,
 }: RegisterSubagentCommandsInput): TuiCommandDispose {
   const disposers: TuiCommandDispose[] = [];
 
   if (api.keymap?.registerLayer) {
     disposers.push(
       api.keymap.registerLayer({
-      commands: [
-        {
-          name: SHARED_COMMAND_METADATA.toggle.id,
-          title: SHARED_COMMAND_METADATA.toggle.title,
-          description: SHARED_COMMAND_METADATA.toggle.description,
-          category: SHARED_COMMAND_METADATA.toggle.category,
-          run: () => toggleSection(!sectionEnabled()),
-        },
-        {
-          name: SHARED_COMMAND_METADATA.focus.id,
-          title: SHARED_COMMAND_METADATA.focus.title,
-          description: SHARED_COMMAND_METADATA.focus.description,
-          category: SHARED_COMMAND_METADATA.focus.category,
-          run: focusSidebarList,
-        },
-      ],
-      bindings: [
-        {
-          key: "alt+b",
-          cmd: SHARED_COMMAND_METADATA.focus.id,
-        },
-      ],
-    }),
+        commands: [
+          {
+            name: SHARED_COMMAND_METADATA.toggle.id,
+            title: SHARED_COMMAND_METADATA.toggle.title,
+            description: SHARED_COMMAND_METADATA.toggle.description,
+            category: SHARED_COMMAND_METADATA.toggle.category,
+            run: () => toggleSection(!sectionEnabled()),
+          },
+          {
+            name: SHARED_COMMAND_METADATA.focus.id,
+            title: SHARED_COMMAND_METADATA.focus.title,
+            description: SHARED_COMMAND_METADATA.focus.description,
+            category: SHARED_COMMAND_METADATA.focus.category,
+            run: focusSidebarList,
+          },
+          {
+            name: SHARED_COMMAND_METADATA.toggleCompletedHistory.id,
+            title: SHARED_COMMAND_METADATA.toggleCompletedHistory.title,
+            description:
+              SHARED_COMMAND_METADATA.toggleCompletedHistory.description,
+            category: SHARED_COMMAND_METADATA.toggleCompletedHistory.category,
+            run: toggleCompletedHistory,
+          },
+        ],
+        bindings: [
+          {
+            key: "alt+b",
+            cmd: SHARED_COMMAND_METADATA.focus.id,
+          },
+        ],
+      }),
     );
   }
 
@@ -152,6 +172,13 @@ export function registerSubagentCommands({
           category: SHARED_COMMAND_METADATA.focus.category,
           keybind: "alt+b",
           onSelect: focusSidebarList,
+        },
+        {
+          title: SHARED_COMMAND_METADATA.toggleCompletedHistory.title,
+          value: SHARED_COMMAND_METADATA.toggleCompletedHistory.id,
+          description: SHARED_COMMAND_METADATA.toggleCompletedHistory.description,
+          category: SHARED_COMMAND_METADATA.toggleCompletedHistory.category,
+          onSelect: toggleCompletedHistory,
         },
       ]),
     );

--- a/src/tui.test.ts
+++ b/src/tui.test.ts
@@ -17,6 +17,7 @@ describe("registerSubagentCommands", () => {
     const commandRegister = vi.fn(() => legacyDispose);
     const toggleSection = vi.fn();
     const focusSidebarList = vi.fn();
+    const toggleCompletedHistory = vi.fn();
 
     const result = registerSubagentCommands({
       api: {
@@ -26,6 +27,7 @@ describe("registerSubagentCommands", () => {
       sectionEnabled: () => true,
       toggleSection,
       focusSidebarList,
+      toggleCompletedHistory,
     });
 
     expect(commandRegister).toHaveBeenCalledOnce();
@@ -42,6 +44,11 @@ describe("registerSubagentCommands", () => {
           title: "Subagents: Focus sidebar list",
           run: expect.any(Function),
         }),
+        expect.objectContaining({
+          name: "subagent-statusline.toggle-completed-history",
+          title: "Subagents: Toggle completed history",
+          run: expect.any(Function),
+        }),
       ],
       bindings: [
         {
@@ -54,14 +61,17 @@ describe("registerSubagentCommands", () => {
     const layer = registerLayer.mock.calls[0]?.[0];
     layer?.commands?.[0]?.run();
     layer?.commands?.[1]?.run();
+    layer?.commands?.[2]?.run();
 
     const legacyCommands = commandRegister.mock.calls[0]?.[0]?.();
     legacyCommands?.[0]?.onSelect?.();
     legacyCommands?.[1]?.onSelect?.();
+    legacyCommands?.[2]?.onSelect?.();
 
     expect(toggleSection).toHaveBeenNthCalledWith(1, false);
     expect(toggleSection).toHaveBeenNthCalledWith(2, false);
     expect(focusSidebarList).toHaveBeenCalledTimes(2);
+    expect(toggleCompletedHistory).toHaveBeenCalledTimes(2);
 
     expect(legacyCommands).toEqual([
       expect.objectContaining({
@@ -73,6 +83,11 @@ describe("registerSubagentCommands", () => {
         title: "Subagents: Focus sidebar list",
         value: "subagent-statusline.focus-sidebar-list",
         keybind: "alt+b",
+      }),
+      expect.objectContaining({
+        title: "Subagents: Toggle completed history",
+        value: "subagent-statusline.toggle-completed-history",
+        description: expect.stringContaining("Shortcut: c"),
       }),
     ]);
 
@@ -90,6 +105,7 @@ describe("registerSubagentCommands", () => {
     const registerLayer = vi.fn(() => dispose);
     const toggleSection = vi.fn();
     const focusSidebarList = vi.fn();
+    const toggleCompletedHistory = vi.fn();
 
     const result = registerSubagentCommands({
       api: {
@@ -98,6 +114,7 @@ describe("registerSubagentCommands", () => {
       sectionEnabled: () => true,
       toggleSection,
       focusSidebarList,
+      toggleCompletedHistory,
     });
 
     expect(registerLayer).toHaveBeenCalledOnce();
@@ -111,8 +128,10 @@ describe("registerSubagentCommands", () => {
 
     layer?.commands?.[0]?.run();
     layer?.commands?.[1]?.run();
+    layer?.commands?.[2]?.run();
     expect(toggleSection).toHaveBeenCalledWith(false);
     expect(focusSidebarList).toHaveBeenCalledOnce();
+    expect(toggleCompletedHistory).toHaveBeenCalledOnce();
 
     result();
     expect(dispose).toHaveBeenCalledOnce();
@@ -123,12 +142,14 @@ describe("registerSubagentCommands", () => {
     const register = vi.fn(() => dispose);
     const toggleSection = vi.fn();
     const focusSidebarList = vi.fn();
+    const toggleCompletedHistory = vi.fn();
 
     const result = registerSubagentCommands({
       api: { command: { register } },
       sectionEnabled: () => false,
       toggleSection,
       focusSidebarList,
+      toggleCompletedHistory,
     });
 
     expect(register).toHaveBeenCalledOnce();
@@ -142,12 +163,18 @@ describe("registerSubagentCommands", () => {
         value: "subagent-statusline.focus-sidebar-list",
         keybind: "alt+b",
       }),
+      expect.objectContaining({
+        value: "subagent-statusline.toggle-completed-history",
+        description: expect.stringContaining("sidebar list is focused"),
+      }),
     ]);
 
     legacyCommands?.[0]?.onSelect?.();
     legacyCommands?.[1]?.onSelect?.();
+    legacyCommands?.[2]?.onSelect?.();
     expect(toggleSection).toHaveBeenCalledWith(true);
     expect(focusSidebarList).toHaveBeenCalledOnce();
+    expect(toggleCompletedHistory).toHaveBeenCalledOnce();
 
     result();
     expect(dispose).toHaveBeenCalledOnce();
@@ -159,6 +186,7 @@ describe("registerSubagentCommands", () => {
       sectionEnabled: () => false,
       toggleSection: vi.fn(),
       focusSidebarList: vi.fn(),
+      toggleCompletedHistory: vi.fn(),
     });
 
     expect(() => result()).not.toThrow();
@@ -181,6 +209,7 @@ describe("registerSubagentCommands", () => {
       sectionEnabled: () => false,
       toggleSection: vi.fn(),
       focusSidebarList: vi.fn(),
+      toggleCompletedHistory: vi.fn(),
     });
 
     expect(() => result()).not.toThrow();

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -938,12 +938,17 @@ function SidebarSubagents(props: {
   sidebarWidth?: () => number | undefined;
   theme: TuiThemeCurrent;
 }) {
+  const [showCompletedHistory, setShowCompletedHistory] = createSignal(false);
+  const completedHistoryOptions = () => ({
+    showCompletedHistory: showCompletedHistory(),
+  });
   const children = createMemo(() =>
     visibleSubagentWorkItems(
       Object.values(props.state().children).filter(
         (child) => child.parentID === props.sessionID,
       ),
       props.nowMs(),
+      completedHistoryOptions(),
     ).sort(byPriority),
   );
 
@@ -953,6 +958,7 @@ function SidebarSubagents(props: {
         (child) => child.parentID !== props.sessionID,
       ),
       props.nowMs(),
+      completedHistoryOptions(),
     ).sort(byPriority),
   );
 
@@ -1149,6 +1155,10 @@ function SidebarSubagents(props: {
     navigateToSessionTarget(props.api, selectedTargetSessionID());
   };
 
+  const toggleCompletedHistory = (): void => {
+    setShowCompletedHistory((current) => !current);
+  };
+
   createEffect(() => {
     selectedChildID();
     listHeight();
@@ -1170,6 +1180,8 @@ function SidebarSubagents(props: {
       if (props.expanded()) props.onSetExpanded(false);
     } else if (name === "l" || name === "right" || name === "arrowright") {
       if (!props.expanded()) props.onSetExpanded(true);
+    } else if (name === "c") {
+      toggleCompletedHistory();
     } else if (name === "escape" || name === "esc") {
       focusRegistration.blurList();
       props.onReturnFocus();
@@ -1390,7 +1402,12 @@ function SidebarSubagents(props: {
       <text fg={props.theme.textMuted}> · </text>
       <text fg={props.theme.error}>{`✕ ${counts().error} err`}</text>
       <text fg={props.theme.textMuted}> · </text>
-      <text fg={props.theme.text}>{`Σ ${totalExecuted()}`}</text>
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: OpenTUI text supports mouse targets. */}
+      <text
+        fg={showCompletedHistory() ? props.theme.accent : props.theme.text}
+        selectable={false}
+        onMouseDown={toggleCompletedHistory}
+      >{`Σ ${totalExecuted()}`}</text>
     </box>
   );
 

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -128,8 +128,14 @@ interface SidebarListFocusRegistration {
   isListFocusModeActive: () => boolean;
 }
 
+interface SidebarCompletedHistoryRegistration {
+  toggleCompletedHistory: () => boolean;
+}
+
 const sidebarScrollRegistrations = new Set<SidebarScrollRegistration>();
 const sidebarListFocusRegistrations = new Set<SidebarListFocusRegistration>();
+const sidebarCompletedHistoryRegistrations =
+  new Set<SidebarCompletedHistoryRegistration>();
 
 function focusVisibleSidebarSubagentList(preferredChildID?: string): boolean {
   for (const registration of [...sidebarListFocusRegistrations].reverse()) {
@@ -149,6 +155,15 @@ function isAnySidebarSubagentListFocused(): boolean {
   return [...sidebarListFocusRegistrations].some((registration) =>
     registration.isListFocusModeActive(),
   );
+}
+
+function toggleVisibleSidebarCompletedHistory(): boolean {
+  for (const registration of [
+    ...sidebarCompletedHistoryRegistrations,
+  ].reverse()) {
+    if (registration.toggleCompletedHistory()) return true;
+  }
+  return false;
 }
 
 function maxScrollTop(scrollbox: ScrollBoxRenderable): number {
@@ -1053,9 +1068,17 @@ function SidebarSubagents(props: {
     isListFocusModeActive: () => listFocusModeActive(),
   };
   sidebarListFocusRegistrations.add(focusRegistration);
+  const completedHistoryRegistration: SidebarCompletedHistoryRegistration = {
+    toggleCompletedHistory: () => {
+      setShowCompletedHistory((current) => !current);
+      return true;
+    },
+  };
+  sidebarCompletedHistoryRegistrations.add(completedHistoryRegistration);
   onCleanup(() => {
     sidebarScrollRegistrations.delete(scrollRegistration);
     sidebarListFocusRegistrations.delete(focusRegistration);
+    sidebarCompletedHistoryRegistrations.delete(completedHistoryRegistration);
     if (restoreScrollTimeout) clearTimeout(restoreScrollTimeout);
   });
 
@@ -1156,7 +1179,7 @@ function SidebarSubagents(props: {
   };
 
   const toggleCompletedHistory = (): void => {
-    setShowCompletedHistory((current) => !current);
+    completedHistoryRegistration.toggleCompletedHistory();
   };
 
   createEffect(() => {
@@ -2069,11 +2092,23 @@ function initializeTui(api: TuiPluginApi, disposeRoot: () => void): void {
     }, 0);
   };
 
+  const toggleSidebarCompletedHistory = (): void => {
+    api.ui.dialog.clear();
+    setSubagentsSectionEnabled(true);
+    setSubagentsExpanded(true);
+    api.kv.set(SUBAGENTS_SECTION_ENABLED_KV_KEY, true);
+    api.kv.set(SUBAGENTS_EXPANDED_KV_KEY, true);
+    setTimeout(() => {
+      toggleVisibleSidebarCompletedHistory();
+    }, 0);
+  };
+
   const commandDispose = registerSubagentCommands({
     api,
     sectionEnabled: subagentsSectionEnabled,
     toggleSection: setSubagentsSectionEnabledPreference,
     focusSidebarList: toggleSidebarListFocus,
+    toggleCompletedHistory: toggleSidebarCompletedHistory,
   });
 
   const clearHydrateRetryTimeout = (sessionID: string): void => {

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -962,9 +962,15 @@ function SidebarSubagents(props: {
     ).sort(byPriority),
   );
 
+  const visibleChildren = createMemo(() => {
+    const ownChildren = children();
+    if (ownChildren.length > 0) return ownChildren;
+    return otherChildren();
+  });
+
   const counts = createMemo(() => {
     const result = { running: 0, done: 0, error: 0 };
-    for (const child of children()) {
+    for (const child of visibleChildren()) {
       if (child.status === "running") result.running += 1;
       if (child.status === "done") result.done += 1;
       if (child.status === "error") result.error += 1;
@@ -972,12 +978,6 @@ function SidebarSubagents(props: {
     return result;
   });
   const totalExecuted = createMemo(() => props.state().totalExecuted ?? 0);
-
-  const visibleChildren = createMemo(() => {
-    const ownChildren = children();
-    if (ownChildren.length > 0) return ownChildren;
-    return otherChildren();
-  });
 
   const showingOtherSessions = createMemo(
     () => children().length === 0 && otherChildren().length > 0,


### PR DESCRIPTION
## Summary

Closes #59.

This PR adds a transient completed history toggle to the TUI sidebar.

* Press `c` while the sidebar list is focused, or click `Σ`, to show retained completed subagents.
* The default sidebar/statusline behavior remains unchanged.
* The toggle is not persisted, so it resets after reload/resume and should not surprise existing users.
* No env var or config change is required.

Issue #59 originally suggested an opt-in display mode. I implemented this as a standard transient UI toggle because the default view stays the same unless the user explicitly toggles completed history. If you would still prefer this to be config-gated or handled differently, I am happy to revise the approach.

I also considered restoring completed sessions as persistent history, but that would be a much larger change with broader state/API implications. This PR keeps the scope bounded: completed history only shows rows that are still retained in plugin state.

The retention window is extended from `1h / 500` terminal rows to `3d / 1500` terminal rows. The previous limit felt too short for the intended short-term history/resume use case, while the new limit is still bounded and not meant to become a long-term audit log. Rows already pruned from state, or sessions not returned by OpenCode APIs, are not restored.

### Follow-up note

While testing with the longer retention window, I noticed two pre-existing sidebar issues that become easier to reproduce when more completed history is retained:

* A clickability issue where a subagent that was once marked as `done` appears in the list after being invoked again and resuming work, but cannot be clicked.
* Auto-scroll jitter that may occur when the subagent history grows longer.

I have identified the likely causes, and once this PR settles, I’m planning to open a separate fix PR for these issues to keep this PR properly scoped.

## Validation

* `pnpm typecheck`
* `pnpm build`
* `pnpm exec vitest run src/render.test.ts`
* `pnpm exec vitest run src/state.test.ts -t "prunes old terminal children without losing running children"`
* Manual OpenCode smoke test:

  * verified `Σ` click toggles completed history
  * verified `c` toggles completed history while the sidebar list is focused
  * verified toggling off returns to the default filtered view

## Screenshots

Default view:
<img width="448" height="264" alt="tui-sidebar-completed-history-hidden" src="https://github.com/user-attachments/assets/c9a81634-cafd-4c59-a618-bb1a6afccd25" />

Shown after toggling:
<img width="455" height="473" alt="tui-sidebar-completed-history-shown" src="https://github.com/user-attachments/assets/dcb37ce4-7508-4132-b96f-064c0a0d477c" />

## Checklist

- [x] I used a Conventional Commit title (e.g. `fix: ...`, `feat: ...`, `docs: ...`)
- [x] I linked related issue(s), or explained why none are needed
- [x] I did not include secrets, credentials, or private data
- [x] I called out any security-sensitive behavior changes
- [x] I updated docs when behavior or usage changed
