### PR TITLE
fix(tui): prevent sidebar scroll jitter

### DIFF
--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -1113,7 +1113,7 @@ function SidebarSubagents(props: {
   };
 
   const scrollSelectedChildIntoView = (): void => {
-    if (!scrollbox) return;
+    if (!scrollbox || !listFocusModeActive()) return;
     const selectedIndex = visibleChildIDs().findIndex(
       (id) => id === selectedChildID(),
     );


### PR DESCRIPTION
## Summary

- Closes #64
- Gate selected-row auto-scroll behind sidebar list focus mode.
- Preserve keyboard navigation auto-scroll while avoiding mouse-wheel scroll jitter.

## Validation

- [x] `pnpm --config.verify-deps-before-run=false run typecheck`
- [x] `pnpm --config.verify-deps-before-run=false run build`
- [x] `pnpm --config.verify-deps-before-run=false exec vitest run src/tui.test.ts`
- [x] Fresh diff review completed with no blocking findings.

## Checklist

- [x] I used a Conventional Commit title (e.g. `fix: ...`, `feat: ...`, `docs: ...`)
- [x] I linked related issue(s), or explained why none are needed
- [x] I did not include secrets, credentials, or private data
- [x] I called out any security-sensitive behavior changes
- [x] I updated docs when behavior or usage changed

Security-sensitive behavior changes: none.
Docs update: not needed, internal TUI scroll behavior fix only.