### PR TITLE
fix(tui): handle wide text in sidebar rows

### DIFF
--- a/docs/en/07-tui-interface.md
+++ b/docs/en/07-tui-interface.md
@@ -28,6 +28,10 @@ It can include:
 - navigable session indicator;
 - current-session or other-session grouping.
 
+Long labels and summaries are compacted using terminal column width rather than
+JavaScript string length. This keeps wide CJK/full-width text, such as Japanese
+summaries, within the sidebar budget when wrapping or truncating rows.
+
 Conceptual example:
 
 ```txt

--- a/docs/en/09-development-and-testing.md
+++ b/docs/en/09-development-and-testing.md
@@ -89,6 +89,7 @@ Deep visual TUI E2E automation is intentionally deferred to avoid brittle host-d
 | `src/state.test.ts` | State, counters, transitions, pruning, persistence, normalization. |
 | `src/render.test.ts` | Text rendering, collapse, visibility, duration, tokens, color/no-color. |
 | `src/reconcile.test.ts` | Status normalization, stale-running, backoff, fail-closed behavior. |
+| `src/text-width.test.ts` | Terminal column width for CJK/full-width text, combining marks, and truncation. |
 | `src/tui.test.ts` | Command registration, `Alt+B` keybinding, legacy fallback. |
 | `test/index.integration.test.ts` | Runtime plugin, `state.json`, `status.txt`, preserve-state, filesystem failures. |
 | `test/helpers/runtime-harness.ts` | Helpers for temp dirs, fixtures, env vars, and fake time. |
@@ -111,7 +112,7 @@ Important:
 
 > `src/tui.tsx` is excluded from coverage. Do not claim the complete visual TUI is automatically covered.
 
-Coverage focuses on deterministic `.ts` modules: events, state, render, reconcile, commands, and runtime.
+Coverage focuses on deterministic `.ts` modules: events, state, render, reconcile, text width helpers, commands, and runtime.
 
 ## Arrange / Act / Assert
 

--- a/docs/es/07-interfaz-tui.md
+++ b/docs/es/07-interfaz-tui.md
@@ -28,6 +28,11 @@ Puede incluir:
 - indicador de sesión navegable;
 - agrupación por sesión actual u otras sesiones.
 
+Los títulos y summaries largos se compactan usando ancho de columnas de terminal,
+no longitud de string de JavaScript. Esto mantiene texto CJK/full-width, como
+summaries en japonés, dentro del ancho disponible de la sidebar al envolver o
+truncar filas.
+
 Ejemplo conceptual:
 
 ```txt

--- a/docs/es/09-desarrollo-y-testing.md
+++ b/docs/es/09-desarrollo-y-testing.md
@@ -95,6 +95,7 @@ La UI visual completa se deja fuera de E2E profundo por ahora para evitar tests 
 | `src/state.test.ts`               | Estado, contadores, transiciones, poda, persistencia y normalización.                   |
 | `src/render.test.ts`              | Render textual, collapse, visibilidad, duración, tokens y color/no-color.               |
 | `src/reconcile.test.ts`           | Normalización de estados, stale-running, backoff y fail-closed.                         |
+| `src/text-width.test.ts`          | Ancho de columnas para texto CJK/full-width, marcas combinantes y truncado.              |
 | `src/tui.test.ts`                 | Registro de comandos, keybinding `Alt+B` y fallback legacy.                             |
 | `test/index.integration.test.ts`  | Plugin runtime, `state.json`, `status.txt`, preserve-state y errores de filesystem.     |
 | `test/helpers/runtime-harness.ts` | Helpers para temp dirs, fixtures, env vars y fake time.                                 |
@@ -117,7 +118,7 @@ Punto importante:
 
 > `src/tui.tsx` está excluido de coverage. No digas que la TUI visual completa está cubierta por tests automáticos.
 
-La cobertura actual se enfoca en módulos `.ts` determinísticos: eventos, estado, render, reconcile, comandos y runtime.
+La cobertura actual se enfoca en módulos `.ts` determinísticos: eventos, estado, render, reconcile, helpers de ancho textual, comandos y runtime.
 
 ## Patrón Arrange / Act / Assert
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -6,7 +6,7 @@ This project uses **Vitest** for automated tests and **@vitest/coverage-v8** for
 
 The suite has two layers:
 
-- **Unit tests** cover pure logic in `src/events.ts`, `src/state.ts`, and `src/render.ts`. These tests should be fast, table-friendly, and focused on behavior: parsed session data, state transitions, counters, formatting, and safe handling of malformed input.
+- **Unit tests** cover pure logic in `src/events.ts`, `src/state.ts`, `src/render.ts`, and focused helpers such as `src/text-width.ts`. These tests should be fast, table-friendly, and focused on behavior: parsed session data, state transitions, counters, formatting, terminal text width, and safe handling of malformed input.
 - **Runtime integration tests** cover `src/index.ts`, where the plugin touches the filesystem and OpenCode-style event handling. These tests instantiate the plugin against isolated temporary directories and assert persisted state/output.
 
 Deep TUI and full OpenCode host end-to-end automation are intentionally deferred. The current priority is a reliable core runtime layer before adding expensive or brittle UI automation.
@@ -18,6 +18,7 @@ Deep TUI and full OpenCode host end-to-end automation are intentionally deferred
 | `src/events.test.ts`              | Event parsing, session ID extraction, event-to-state updates, details/token normalization, and malformed event safety.                                             |
 | `src/state.test.ts`               | State invariants, counters, transitions, pruning, persistence helpers, environment path resolution, and detail merging.                                            |
 | `src/render.test.ts`              | Statusline rendering, visibility rules, collapse behavior, duration/token formatting, and color/no-color output semantics.                                         |
+| `src/text-width.test.ts`          | Terminal column width helpers for CJK/full-width text, combining marks, and truncation within display budgets.                                                     |
 | `test/index.integration.test.ts`  | Runtime plugin initialization, event handling, `state.json` persistence, `status.txt` writes, preserve-state behavior, malformed events, and write-failure safety. |
 | `test/helpers/runtime-harness.ts` | Reusable helpers for temp dirs, env overrides, fixtures, filesystem assertions, and fake-time setup.                                                               |
 | `test/setup.ts`                   | Global cleanup after each test: timers, mocks, selected env vars, and registered temp directories.                                                                 |
@@ -82,7 +83,7 @@ pnpm typecheck
 ## Adding a unit test
 
 1. Pick the module behavior you want to protect.
-2. Add or extend the co-located test file: `src/events.test.ts`, `src/state.test.ts`, or `src/render.test.ts`.
+2. Add or extend the co-located test file: `src/events.test.ts`, `src/state.test.ts`, `src/render.test.ts`, or another focused unit test such as `src/text-width.test.ts`.
 3. Arrange minimal inputs. Reuse existing helpers or fixtures only when they make the test clearer.
 4. Act by calling the public function under test.
 5. Assert behavior, not implementation details.

--- a/src/text-width.test.ts
+++ b/src/text-width.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { takeColumns, textColumns, truncateToColumns } from "./text-width.js";
+
+describe("textColumns", () => {
+  it("counts Japanese full-width characters as two terminal columns", () => {
+    expect(textColumns("日本語summary")).toBe(13);
+  });
+
+  it("does not count combining marks as extra terminal columns", () => {
+    expect(textColumns("e\u0301")).toBe(1);
+  });
+});
+
+describe("takeColumns", () => {
+  it("keeps returned text within the requested terminal column budget", () => {
+    expect(takeColumns("日本語summary", 6)).toBe("日本語");
+    expect(textColumns(takeColumns("日本語summary", 7))).toBeLessThanOrEqual(7);
+  });
+});
+
+describe("truncateToColumns", () => {
+  it("truncates Japanese text by terminal columns instead of string length", () => {
+    const result = truncateToColumns("日本語の概要を表示しています", 10);
+
+    expect(result).toBe("日本語の…");
+    expect(textColumns(result)).toBeLessThanOrEqual(10);
+  });
+
+  it("leaves text unchanged when its terminal column width fits", () => {
+    expect(truncateToColumns("日本語", 6)).toBe("日本語");
+  });
+});

--- a/src/text-width.ts
+++ b/src/text-width.ts
@@ -1,0 +1,77 @@
+const ELLIPSIS = "…";
+
+function isCombiningCodePoint(codePoint: number): boolean {
+  return (
+    (codePoint >= 0x0300 && codePoint <= 0x036f) ||
+    (codePoint >= 0x1ab0 && codePoint <= 0x1aff) ||
+    (codePoint >= 0x1dc0 && codePoint <= 0x1dff) ||
+    (codePoint >= 0x20d0 && codePoint <= 0x20ff) ||
+    (codePoint >= 0xfe00 && codePoint <= 0xfe0f) ||
+    (codePoint >= 0xfe20 && codePoint <= 0xfe2f)
+  );
+}
+
+function isWideCodePoint(codePoint: number): boolean {
+  return (
+    codePoint >= 0x1100 &&
+    (codePoint <= 0x115f ||
+      codePoint === 0x2329 ||
+      codePoint === 0x232a ||
+      (codePoint >= 0x2e80 && codePoint <= 0xa4cf && codePoint !== 0x303f) ||
+      (codePoint >= 0xac00 && codePoint <= 0xd7a3) ||
+      (codePoint >= 0xf900 && codePoint <= 0xfaff) ||
+      (codePoint >= 0xfe10 && codePoint <= 0xfe19) ||
+      (codePoint >= 0xfe30 && codePoint <= 0xfe6f) ||
+      (codePoint >= 0xff00 && codePoint <= 0xff60) ||
+      (codePoint >= 0xffe0 && codePoint <= 0xffe6) ||
+      (codePoint >= 0x1f300 && codePoint <= 0x1f64f) ||
+      (codePoint >= 0x1f680 && codePoint <= 0x1f6ff) ||
+      (codePoint >= 0x20000 && codePoint <= 0x3fffd))
+  );
+}
+
+function characterWidth(character: string): number {
+  const codePoint = character.codePointAt(0);
+  if (codePoint === undefined) return 0;
+  if (
+    codePoint === 0 ||
+    codePoint < 0x20 ||
+    (codePoint >= 0x7f && codePoint < 0xa0)
+  ) {
+    return 0;
+  }
+  if (codePoint === 0x200d || isCombiningCodePoint(codePoint)) return 0;
+  return isWideCodePoint(codePoint) ? 2 : 1;
+}
+
+export function textColumns(value: string): number {
+  let columns = 0;
+  for (const character of value) columns += characterWidth(character);
+  return columns;
+}
+
+export function takeColumns(value: string, maxColumns: number): string {
+  if (maxColumns <= 0) return "";
+
+  let columns = 0;
+  let result = "";
+  for (const character of value) {
+    const width = characterWidth(character);
+    if (columns + width > maxColumns) break;
+    columns += width;
+    result += character;
+  }
+  return result;
+}
+
+export function truncateToColumns(value: string, maxColumns: number): string {
+  if (maxColumns <= 0) return "";
+  if (textColumns(value) <= maxColumns) return value;
+  if (maxColumns <= textColumns(ELLIPSIS)) return ELLIPSIS;
+
+  const prefix = takeColumns(
+    value,
+    maxColumns - textColumns(ELLIPSIS),
+  ).trimEnd();
+  return `${prefix}${ELLIPSIS}`;
+}

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -20,21 +20,16 @@ import { dirname, join } from "node:path";
 import {
   For,
   Show,
-  createRoot,
   createEffect,
   createMemo,
+  createRoot,
   createSignal,
   onCleanup,
 } from "solid-js";
 import type { Accessor } from "solid-js";
 import { applySubagentEvent, extractChildDetails } from "./events.js";
+import { t } from "./i18n.js";
 import { readOpenCodeLogFileIfSmall } from "./logs.js";
-import {
-  byPriority,
-  formatDuration,
-  renderStatusLine,
-  visibleSubagentWorkItems,
-} from "./render.js";
 import {
   canSafelyCloseNoTargetPersistedCandidate,
   capCandidates,
@@ -51,9 +46,11 @@ import {
   type RunningReconcileEvidence,
 } from "./reconcile.js";
 import {
-  focusPromptWithDeferredRetry,
-  resolveSidebarReturnFocusAction,
-} from "./tui-focus.js";
+  byPriority,
+  formatDuration,
+  renderStatusLine,
+  visibleSubagentWorkItems,
+} from "./render.js";
 import {
   createEmptyState,
   markChildStatus,
@@ -67,8 +64,12 @@ import {
   type ChildSessionState,
   type StatuslineState,
 } from "./state.js";
+import { takeColumns, textColumns, truncateToColumns } from "./text-width.js";
 import { registerSubagentCommands } from "./tui-commands.js";
-import { t } from "./i18n.js";
+import {
+  focusPromptWithDeferredRetry,
+  resolveSidebarReturnFocusAction,
+} from "./tui-focus.js";
 
 const TUI_PLUGIN_ID = "subagent-statusline.tui";
 const ELAPSED_TICK_MS = 1000;
@@ -717,11 +718,8 @@ function resolveSidebarWidth(ctx: unknown): number | undefined {
   );
 }
 
-function ellipsize(value: string, maxChars: number): string {
-  if (maxChars <= 0) return "";
-  if (value.length <= maxChars) return value;
-  if (maxChars <= 1) return "…";
-  return `${value.slice(0, Math.max(0, maxChars - 1))}…`;
+function ellipsize(value: string, maxColumns: number): string {
+  return truncateToColumns(value, maxColumns);
 }
 
 function splitParentheticalTitle(title: string): {
@@ -755,7 +753,7 @@ function formatSecondaryLine(
   if (!continuation) return parenthetical;
   if (!parenthetical) return continuation;
 
-  const parentheticalWidth = Math.min(parenthetical.length, width);
+  const parentheticalWidth = Math.min(textColumns(parenthetical), width);
   const continuationWidth = width - parentheticalWidth - 1;
   if (continuationWidth >= MIN_LABEL_WIDTH) {
     return `${ellipsize(continuation, continuationWidth)} ${ellipsize(parenthetical, parentheticalWidth)}`;
@@ -827,10 +825,13 @@ function wrapCompactText(
   const lines: string[] = [];
   let remaining = normalized;
 
-  while (remaining.length > width && lines.length < maxLines - 1) {
-    const slice = remaining.slice(0, width + 1);
+  while (textColumns(remaining) > width && lines.length < maxLines - 1) {
+    const slice = takeColumns(remaining, width + 1);
     const breakAt = slice.lastIndexOf(" ");
-    const take = breakAt >= MIN_LABEL_WIDTH ? breakAt : width;
+    const take =
+      breakAt >= 0 && textColumns(slice.slice(0, breakAt)) >= MIN_LABEL_WIDTH
+        ? breakAt
+        : Math.max(1, slice.length);
     lines.push(remaining.slice(0, take).trimEnd());
     remaining = remaining.slice(take).trimStart();
   }
@@ -863,12 +864,13 @@ function formatChildRowLine(input: {
   const parenthetical = childParenthetical(input.child);
 
   for (const meta of contextVariants(input.child)) {
-    const detailChars = 2 + elapsed.length + (meta ? 3 + meta.length : 0);
+    const detailChars =
+      2 + textColumns(elapsed) + (meta ? 3 + textColumns(meta) : 0);
     const labelBudget = Math.min(
       width - 2,
       width - Math.max(0, detailChars - width),
     );
-    if (labelBudget >= MIN_LABEL_WIDTH || meta.length === 0) {
+    if (labelBudget >= MIN_LABEL_WIDTH || textColumns(meta) === 0) {
       const labelLines = wrapCompactText(
         title.label,
         Math.max(1, labelBudget),


### PR DESCRIPTION
## Summary

Closes #70

Fixed a rendering issue in the TUI sidebar subagent row where CJK / full-width summaries, such as Japanese text, could break the layout.

Previously, sidebar row wrapping and truncation were based on JavaScript's `string.length` / `slice()`. However, in terminals, full-width characters such as Japanese characters are typically rendered as 2 columns wide. As a result, text could appear to fit according to the internal calculation while actually exceeding the sidebar width on screen.

This PR makes the following changes:

* Added a helper for calculating terminal column width
* Treats CJK / full-width characters as 2 columns wide
* Excludes combining marks, variation selectors, and control characters from additional width calculation
* Changes TUI sidebar row `ellipsize`, wrapping, secondary line, and elapsed/meta budget calculation to be display-width based
* Adds regression tests for CJK / full-width text
* Minimally updates TUI docs and testing docs

## Validation

Locally ran:

- `pnpm install --ignore-scripts`
- `pnpm typecheck`
- `pnpm vitest run src/text-width.test.ts`
- `pnpm build`

Also ran:

- `pnpm test`

Result:

- The new text width tests passed.
- Typecheck passed.
- Build passed.
- Markdown lint for edited docs passed with 0 errors.
- `pnpm test` has one known Windows-specific file mode assertion failure in `src/state.test.ts` (`0o700` expected, `0o666` received). This is unrelated to this TUI text-width change.

Manual validation:

- Tested the local built TUI plugin in OpenCode.
- Japanese / full-width summary display looked correct in the sidebar during initial manual QA.

## Note

This PR is independent of #69 and should not conflict with it. I’m happy to rebase if needed.

## Checklist

- [x] I used a Conventional Commit title (e.g. `fix: ...`, `feat: ...`, `docs: ...`)
- [x] I linked related issue(s), or explained why none are needed
- [x] I did not include secrets, credentials, or private data
- [x] I called out any security-sensitive behavior changes
- [x] I updated docs when behavior or usage changed
