### PR TITLE
fix(tui): prevent ghost clicks after opening child sessions

### DIFF
--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -9,6 +9,7 @@ import type {
 import type {
   BoxRenderable,
   KeyEvent,
+  MouseEvent,
   ScrollBoxRenderable,
 } from "@opentui/core";
 import { useKeyboard } from "@opentui/solid";
@@ -1152,6 +1153,9 @@ function SidebarSubagents(props: {
   const [selectedChildID, setSelectedChildID] = createSignal<
     string | undefined
   >();
+  const [mouseDownChildID, setMouseDownChildID] = createSignal<
+    string | undefined
+  >();
   const [listFocused, setListFocused] = createSignal(false);
   const [listFocusModeActive, setListFocusModeActive] = createSignal(false);
 
@@ -1564,14 +1568,27 @@ function SidebarSubagents(props: {
             ? () => {
                 setHovered(false);
                 setFocused(false);
+                setMouseDownChildID(undefined);
               }
             : undefined
         }
         onMouseDown={
           clickable()
-            ? () => {
+            ? (event: MouseEvent) => {
+                event.stopPropagation();
                 setSelectedChildID(rowProps.childID);
-                activate();
+                setMouseDownChildID(rowProps.childID);
+              }
+            : undefined
+        }
+        onMouseUp={
+          clickable()
+            ? (event: MouseEvent) => {
+                if (mouseDownChildID() === rowProps.childID) {
+                  event.stopPropagation();
+                  activate();
+                }
+                setMouseDownChildID(undefined);
               }
             : undefined
         }


### PR DESCRIPTION
## Summary

Closes #73

Fixes an issue where clicking a subagent history row to navigate to a child session caused unintended clicks, popups, or text selections in the destination conversation.

The root cause was that `ChildRow` called `api.route.navigate("session", ...)` synchronously inside `onMouseDown`, switching the view while the mouse button was still pressed. The subsequent `MouseUp` was then handled by a different element on the new session screen.

Changes:

- Added a `mouseDownChildID` state at the `SidebarSubagents` level
- Record the pressed row on `onMouseDown`
- Only call `activate()` to navigate on `onMouseUp` if the mouse was released on the same row
- Clear the pressed state on `onMouseOut`
- Applied `stopPropagation()` to prevent event propagation
- Did not add `selectable={false}`, preserving normal text selection behavior

## Validation

- `pnpm run typecheck` → pass
- `pnpm run test` → `src/tui.test.ts` 41 tests pass (the one failure in `src/state.test.ts` is an unrelated pre-existing Windows file-mode issue)
- `pnpm run build` → pass
- Manual verification in OpenCode → after clicking a subagent row, no popup or text selection occurs in the destination, and conversation copying still works

## Checklist

- [x] I used a Conventional Commit title (e.g. `fix: ...`, `feat: ...`, `docs: ...`)
- [x] I linked related issue(s), or explained why none are needed
- [x] I did not include secrets, credentials, or private data
- [x] I called out any security-sensitive behavior changes
- [x] I updated docs when behavior or usage changed
