### PR TITLE
feat(tui): preserve subagent sidebar state

### DIFF
--- a/src/tui-focus.ts
+++ b/src/tui-focus.ts
@@ -1,11 +1,48 @@
 export type SidebarReturnFocusAction = "none" | "clear-pending" | "focus-prompt";
 
-export function resolveSidebarReturnFocusAction(input: {
-  pendingSidebarRefocus?: {
-    parentSessionID: string;
-    childSessionID: string;
-    childRowID: string;
+export type PendingSidebarRefocus = {
+  parentSessionID: string;
+  childSessionID: string;
+  childRowID: string;
+  showCompletedHistory?: boolean;
+};
+
+export type ChildSessionState = {
+  id: string;
+  parentID: string;
+  targetSessionID?: string;
+};
+
+export function resolveSiblingSidebarRefocus(input: {
+  pendingSidebarRefocus?: PendingSidebarRefocus;
+  routeSessionID?: string;
+  children: Record<string, ChildSessionState> | ChildSessionState[];
+}): Pick<PendingSidebarRefocus, "childSessionID" | "childRowID"> | undefined {
+  const { pendingSidebarRefocus, routeSessionID, children } = input;
+  if (
+    !pendingSidebarRefocus ||
+    !routeSessionID ||
+    routeSessionID === pendingSidebarRefocus.parentSessionID ||
+    routeSessionID === pendingSidebarRefocus.childSessionID
+  ) {
+    return undefined;
+  }
+
+  const sibling = Object.values(children).find(
+    (child) =>
+      child.parentID === pendingSidebarRefocus.parentSessionID &&
+      child.targetSessionID === routeSessionID,
+  );
+  if (!sibling) return undefined;
+
+  return {
+    childSessionID: routeSessionID,
+    childRowID: sibling.id,
   };
+}
+
+export function resolveSidebarReturnFocusAction(input: {
+  pendingSidebarRefocus?: PendingSidebarRefocus;
   previousRouteSessionID?: string;
   routeSessionID?: string;
 }): SidebarReturnFocusAction {

--- a/src/tui.test.ts
+++ b/src/tui.test.ts
@@ -19,6 +19,7 @@ import { textColumns } from "./text-width.js";
 import {
   focusPromptWithDeferredRetry,
   resolveSidebarReturnFocusAction,
+  resolveSiblingSidebarRefocus,
 } from "./tui-focus.js";
 import { registerSubagentCommands } from "./tui-commands.js";
 import type { ChildSessionState, StatuslineState } from "./state.js";
@@ -1507,6 +1508,19 @@ describe("resolveSidebarReturnFocusAction", () => {
     ).toBe("focus-prompt");
   });
 
+  it("returns focus-prompt while preserving showCompletedHistory", () => {
+    expect(
+      resolveSidebarReturnFocusAction({
+        pendingSidebarRefocus: {
+          ...pendingSidebarRefocus,
+          showCompletedHistory: true,
+        },
+        previousRouteSessionID: "child",
+        routeSessionID: "parent",
+      }),
+    ).toBe("focus-prompt");
+  });
+
   it("returns clear-pending when route leaves remembered child path", () => {
     expect(
       resolveSidebarReturnFocusAction({
@@ -1534,6 +1548,64 @@ describe("resolveSidebarReturnFocusAction", () => {
         routeSessionID: "parent",
       }),
     ).toBe("none");
+  });
+});
+
+describe("resolveSiblingSidebarRefocus", () => {
+  const pendingSidebarRefocus = {
+    parentSessionID: "parent",
+    childSessionID: "child-a",
+    childRowID: "row-a",
+  };
+
+  it("returns updated child row ID when navigating to a sibling subagent", () => {
+    expect(
+      resolveSiblingSidebarRefocus({
+        pendingSidebarRefocus,
+        routeSessionID: "child-b",
+        children: {
+          "row-a": { id: "row-a", parentID: "parent", targetSessionID: "child-a" },
+          "row-b": { id: "row-b", parentID: "parent", targetSessionID: "child-b" },
+        },
+      }),
+    ).toEqual({ childSessionID: "child-b", childRowID: "row-b" });
+  });
+
+  it("returns undefined when route returns to parent", () => {
+    expect(
+      resolveSiblingSidebarRefocus({
+        pendingSidebarRefocus,
+        routeSessionID: "parent",
+        children: {
+          "row-a": { id: "row-a", parentID: "parent", targetSessionID: "child-a" },
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when route stays on recorded child", () => {
+    expect(
+      resolveSiblingSidebarRefocus({
+        pendingSidebarRefocus,
+        routeSessionID: "child-a",
+        children: {
+          "row-a": { id: "row-a", parentID: "parent", targetSessionID: "child-a" },
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when target session is not a sibling", () => {
+    expect(
+      resolveSiblingSidebarRefocus({
+        pendingSidebarRefocus,
+        routeSessionID: "other-child",
+        children: {
+          "row-a": { id: "row-a", parentID: "parent", targetSessionID: "child-a" },
+          "row-other": { id: "row-other", parentID: "other-parent", targetSessionID: "other-child" },
+        },
+      }),
+    ).toBeUndefined();
   });
 });
 

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -60,6 +60,8 @@ import {
 import {
   focusPromptWithDeferredRetry,
   resolveSidebarReturnFocusAction,
+  resolveSiblingSidebarRefocus,
+  type PendingSidebarRefocus,
 } from "./tui-focus.js";
 import {
   createEmptyState,
@@ -1128,11 +1130,18 @@ function SidebarSubagents(props: {
     parentSessionID: string;
     childSessionID: string;
     childRowID: string;
+    showCompletedHistory: boolean;
   }) => void;
   sidebarWidth?: () => number | undefined;
   theme: TuiThemeCurrent;
+  restoreFromChild?: {
+    childRowID: string;
+    showCompletedHistory: boolean;
+  };
 }) {
-  const [showCompletedHistory, setShowCompletedHistory] = createSignal(false);
+  const [showCompletedHistory, setShowCompletedHistory] = createSignal(
+    props.restoreFromChild?.showCompletedHistory ?? false,
+  );
   const completedHistoryOptions = () => ({
     showCompletedHistory: showCompletedHistory(),
   });
@@ -1153,7 +1162,8 @@ function SidebarSubagents(props: {
   );
   const [selectedChildID, setSelectedChildID] = createSignal<
     string | undefined
-  >();
+  >(props.restoreFromChild?.childRowID);
+  let restoreChildRowID = props.restoreFromChild?.childRowID;
   const [mouseDownChildID, setMouseDownChildID] = createSignal<
     string | undefined
   >();
@@ -1448,6 +1458,18 @@ function SidebarSubagents(props: {
     if (scrollRegistration.restoreFramesRemaining <= 0) return;
     scrollRegistration.restoreFramesRemaining -= 1;
 
+    if (restoreChildRowID) {
+      const childRowID = restoreChildRowID;
+      restoreChildRowID = undefined;
+      scrollRegistration.restoreFramesRemaining = 0;
+      if (visibleChildIDs().includes(childRowID)) {
+        scrollChildIntoView(childRowID);
+      } else {
+        scrollbox.scrollTop = 0;
+      }
+      return;
+    }
+
     const top = preservedSidebarScrollTop({
       expanded: props.expanded(),
       offsetTop: scrollRegistration.offsetTop,
@@ -1539,8 +1561,10 @@ function SidebarSubagents(props: {
           parentSessionID: props.sessionID,
           childSessionID: target,
           childRowID: rowProps.childID,
+          showCompletedHistory: showCompletedHistory(),
         });
       }
+      snapshotSidebarScrollOffsets();
       navigateToSessionTarget(props.api, target);
     };
     rowActivations.set(rowProps.childID, activate);
@@ -2406,10 +2430,17 @@ function initializeTui(api: TuiPluginApi, disposeRoot: () => void): void {
   let lastRunningReconcileAtMs = 0;
   let disposed = false;
   let previousRouteSessionID: string | undefined;
-  let pendingSidebarRefocus:
-    | { parentSessionID: string; childSessionID: string; childRowID: string }
-    | undefined;
+  let pendingSidebarRefocus: PendingSidebarRefocus | undefined;
+  let pendingRefocusConsumed = false;
   let activePromptRef: TuiPromptRef | undefined;
+
+  const consumePendingSidebarRefocus = ():
+    | PendingSidebarRefocus
+    | undefined => {
+    if (pendingRefocusConsumed) return undefined;
+    pendingRefocusConsumed = true;
+    return pendingSidebarRefocus;
+  };
 
   const setActivePromptRef = (ref: TuiPromptRef | undefined): void => {
     activePromptRef = ref;
@@ -2434,11 +2465,9 @@ function initializeTui(api: TuiPluginApi, disposeRoot: () => void): void {
     });
   };
 
-  const rememberSidebarChildNavigation = (input: {
-    parentSessionID: string;
-    childSessionID: string;
-    childRowID: string;
-  }): void => {
+  const rememberSidebarChildNavigation = (
+    input: PendingSidebarRefocus,
+  ): void => {
     pendingSidebarRefocus = input;
   };
 
@@ -2537,13 +2566,25 @@ function initializeTui(api: TuiPluginApi, disposeRoot: () => void): void {
       resetHydrateRetry(previousRouteSessionID);
     }
 
+    const siblingRefocus = resolveSiblingSidebarRefocus({
+      pendingSidebarRefocus,
+      routeSessionID,
+      children: state().children,
+    });
+    if (siblingRefocus && pendingSidebarRefocus) {
+      pendingSidebarRefocus = {
+        ...pendingSidebarRefocus,
+        ...siblingRefocus,
+      };
+    }
+
     const sidebarReturnAction = resolveSidebarReturnFocusAction({
       pendingSidebarRefocus,
       previousRouteSessionID,
       routeSessionID,
     });
+    pendingRefocusConsumed = false;
     if (sidebarReturnAction === "focus-prompt") {
-      pendingSidebarRefocus = undefined;
       blurVisibleSidebarSubagentList();
       focusActivePrompt();
     } else if (sidebarReturnAction === "clear-pending") {
@@ -2946,6 +2987,14 @@ function initializeTui(api: TuiPluginApi, disposeRoot: () => void): void {
           route: api.route.current,
           childCount: Object.keys(state().children).length,
         });
+        const restoreFromChild = (() => {
+          const pending = consumePendingSidebarRefocus();
+          if (pending?.parentSessionID !== sessionID) return undefined;
+          return {
+            childRowID: pending.childRowID,
+            showCompletedHistory: pending.showCompletedHistory ?? false,
+          };
+        })();
         return (
           <Show when={subagentsSectionEnabled()}>
             <SidebarSubagents
@@ -2963,6 +3012,7 @@ function initializeTui(api: TuiPluginApi, disposeRoot: () => void): void {
               onNavigateToChild={rememberSidebarChildNavigation}
               sidebarWidth={() => resolveSidebarWidth(ctx)}
               theme={ctx.theme.current}
+              restoreFromChild={restoreFromChild}
             />
           </Show>
         );


### PR DESCRIPTION
## Summary

Closes #75

PR #62 (`feat(tui): add completed history toggle`) added the Σ toggle for completed history to the sidebar, allowing completed subagent history to accumulate.

This PR builds on that feature by restoring the **Σ expanded state and sidebar scroll position** when returning to the parent session from a child session or from an adjacent sibling session.

### Changes

* `src/tui-focus.ts`

  * Add `showCompletedHistory` to the `PendingSidebarRefocus` type
  * Add `resolveSiblingSidebarRefocus`, which updates `childRowID` / `childSessionID` when navigating between sibling sessions
* `src/tui.tsx`

  * Add a `restoreFromChild` prop to `SidebarSubagents` and restore the Σ state / selected row when the component mounts
  * Snapshot sidebar scroll offsets before navigating to a child session
  * Introduce a `consumePendingSidebarRefocus` pattern so `pendingSidebarRefocus` is consumed only once
* `src/tui.test.ts`

  * Add test cases for `resolveSidebarReturnFocusAction`
  * Add tests for `resolveSiblingSidebarRefocus`

### Design Notes

* `showCompletedHistory` is not persisted to KV. It is treated as temporary in-session navigation state, preserving the PR #62 behavior where Σ starts collapsed when a session is opened.
* This PR reuses the existing scroll snapshot/restore flow instead of introducing a separate large scroll-state mechanism.
* If a completed subagent is resumed and the previous row no longer exists, the sidebar keeps Σ expanded but leaves the scroll position at the top.

## Validation

* `pnpm run typecheck` → pass
* `pnpm run test` → `src/tui.test.ts` 41 tests pass

  * The one failure in `src/state.test.ts` is an unrelated pre-existing Windows file-mode issue
* `pnpm run build` → pass

Manual validation with a local build:

* Parent → child → parent:

  * Σ remains expanded
  * The sidebar scroll position is restored
* Parent → child A → child B sibling → parent:

  * The sidebar scrolls back to the row for the last viewed child session, child B
* Resumed completed subagent where the previous row no longer exists:

  * The sidebar remains at the top
  * Σ remains expanded

## Checklist

- [x] I used a Conventional Commit title (e.g. `fix: ...`, `feat: ...`, `docs: ...`)
- [x] I linked related issue(s), or explained why none are needed
- [x] I did not include secrets, credentials, or private data
- [x] I called out any security-sensitive behavior changes
- [x] I updated docs when behavior or usage changed
