### PR TITLE
fix(tui): release sidebar focus after completion

### DIFF
--- a/src/tui-focus.ts
+++ b/src/tui-focus.ts
@@ -13,6 +13,18 @@ export type ChildSessionState = {
   targetSessionID?: string;
 };
 
+export function shouldReleaseSidebarListFocus(input: {
+  previousRunningCount?: number;
+  runningCount: number;
+  listFocusModeActive: boolean;
+}): boolean {
+  return (
+    input.listFocusModeActive &&
+    (input.previousRunningCount ?? 0) > 0 &&
+    input.runningCount === 0
+  );
+}
+
 export function resolveSiblingSidebarRefocus(input: {
   pendingSidebarRefocus?: PendingSidebarRefocus;
   routeSessionID?: string;

--- a/src/tui.test.ts
+++ b/src/tui.test.ts
@@ -20,6 +20,7 @@ import {
   focusPromptWithDeferredRetry,
   resolveSidebarReturnFocusAction,
   resolveSiblingSidebarRefocus,
+  shouldReleaseSidebarListFocus,
 } from "./tui-focus.js";
 import { registerSubagentCommands } from "./tui-commands.js";
 import type { ChildSessionState, StatuslineState } from "./state.js";
@@ -1548,6 +1549,35 @@ describe("resolveSidebarReturnFocusAction", () => {
         routeSessionID: "parent",
       }),
     ).toBe("none");
+  });
+});
+
+describe("shouldReleaseSidebarListFocus", () => {
+  it("releases active list focus when the last running subagent completes", () => {
+    expect(
+      shouldReleaseSidebarListFocus({
+        previousRunningCount: 1,
+        runningCount: 0,
+        listFocusModeActive: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("preserves list focus without a running-to-terminal transition", () => {
+    expect(
+      shouldReleaseSidebarListFocus({
+        previousRunningCount: 0,
+        runningCount: 0,
+        listFocusModeActive: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldReleaseSidebarListFocus({
+        previousRunningCount: 1,
+        runningCount: 0,
+        listFocusModeActive: false,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -61,6 +61,7 @@ import {
   focusPromptWithDeferredRetry,
   resolveSidebarReturnFocusAction,
   resolveSiblingSidebarRefocus,
+  shouldReleaseSidebarListFocus,
   type PendingSidebarRefocus,
 } from "./tui-focus.js";
 import {
@@ -1243,6 +1244,20 @@ function SidebarSubagents(props: {
     isListFocusModeActive: () => listFocusModeActive(),
   };
   sidebarListFocusRegistrations.add(focusRegistration);
+  let previousRunningCount: number | undefined;
+  createEffect(() => {
+    const runningCount = counts().running;
+    const shouldReleaseFocus = shouldReleaseSidebarListFocus({
+      previousRunningCount,
+      runningCount,
+      listFocusModeActive: listFocusModeActive(),
+    });
+    previousRunningCount = runningCount;
+    if (!shouldReleaseFocus) return;
+
+    focusRegistration.blurList();
+    props.onReturnFocus();
+  });
   const completedHistoryRegistration: SidebarCompletedHistoryRegistration = {
     toggleCompletedHistory: () => {
       setShowCompletedHistory((current) => !current);


### PR DESCRIPTION
## Summary

- Release sidebar list focus when the final running subagent completes.
- Return keyboard focus to the prompt so Enter is no longer swallowed by stale sidebar focus.

Closes #77

## Type

- [x] Bug fix

## Validation

- [x] `pnpm typecheck` passed.
- [x] `pnpm test` passed: 9 files, 167 tests.
- [x] `pnpm build` passed (`tsup`).
- [x] `git diff --check` passed.
- Interactive runtime smoke test: N/A because no automated OpenCode TUI harness exists.
- Manual testing was not performed.

## Checklist

- [x] I used a Conventional Commit title (e.g. `fix: ...`, `feat: ...`, `docs: ...`)
- [x] I linked related issue(s), or explained why none are needed
- [x] I did not include secrets, credentials, or private data
- [x] I called out any security-sensitive behavior changes
- [ ] I updated docs when behavior or usage changed

Security-sensitive behavior changes: none. Documentation updates are not required for this focused keyboard-focus bug fix.