### PR TITLE
test(tui): freeze maintenance test clock

### DIFF
--- a/src/tui-maintenance.test.ts
+++ b/src/tui-maintenance.test.ts
@@ -134,6 +134,8 @@ describe("TUI maintenance timers", () => {
 
 describe("TUI state maintenance", () => {
   it("performs zero history reads for terminal children with complete tokens", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-17T09:02:00.000Z"));
     const { api, status, messages, part } = apiWithReadSpies();
     const current = state([child({ tokens: { total: 42 } })]);
 


### PR DESCRIPTION
## Summary

- Freeze the maintenance test clock within the terminal retention TTL.
- Keep the production maintenance behavior unchanged.
- PR type: [x] Maintenance/tooling

Closes #84

## Validation

- [x] Focused tests: 8/8 passed
- [x] Full test suite: 173/173 passed
- [x] Typecheck passed
- [x] Build passed
- [x] Diff check passed
- [x] Runtime: N/A; this is a test-only determinism correction

## Checklist

- [x] I used a Conventional Commit title (e.g. `fix: ...`, `feat: ...`, `docs: ...`)
- [x] I linked related issue(s), or explained why none are needed
- [x] I did not include secrets, credentials, or private data
- [x] I called out any security-sensitive behavior changes
- [x] I updated docs when behavior or usage changed

Security-sensitive behavior changes: none. Documentation is unchanged because runtime behavior is unchanged.