### PR TITLE
chore(deps): update seroval lockfile resolution

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2156,8 +2156,8 @@ packages:
     peerDependencies:
       seroval: ^1.0
 
-  seroval@1.5.2:
-    resolution: {integrity: sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==}
+  seroval@1.5.3:
+    resolution: {integrity: sha512-BXe0x4buEeYiIKaRUnth1WqCILQ3k4O67KP/B4pC3pVz0Mv2c96ngA9QDREUYxWY1sb2RZVRqwI9RcpVMyHCVw==}
     engines: {node: '>=10'}
 
   shebang-command@2.0.0:
@@ -4535,11 +4535,11 @@ snapshots:
 
   semver@7.7.4: {}
 
-  seroval-plugins@1.5.2(seroval@1.5.2):
+  seroval-plugins@1.5.2(seroval@1.5.3):
     dependencies:
-      seroval: 1.5.2
+      seroval: 1.5.3
 
-  seroval@1.5.2: {}
+  seroval@1.5.3: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -4564,8 +4564,8 @@ snapshots:
   solid-js@1.9.12:
     dependencies:
       csstype: 3.2.3
-      seroval: 1.5.2
-      seroval-plugins: 1.5.2(seroval@1.5.2)
+      seroval: 1.5.3
+      seroval-plugins: 1.5.2(seroval@1.5.3)
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
## Summary

- Update the transitive `seroval` lockfile resolution from vulnerable 1.5.2 to patched 1.5.3.
- Keep the maintenance change limited to `pnpm-lock.yaml` without changing declared dependency ranges.
- Security-sensitive change: resolves GHSA-mv8w-475r-vwqw / CVE-2026-59940 in the production dependency graph.

Closes #86

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [x] Maintenance/tooling
- [ ] Breaking change

## Changes

| File | Change |
|------|--------|
| `pnpm-lock.yaml` | Resolve `seroval` and its lockfile references at patched version 1.5.3. |

## Validation

- [x] Frozen install passed: `pnpm install --frozen-lockfile --ignore-scripts`.
- [x] Production audit passed with no known vulnerabilities: `pnpm audit --prod --audit-level moderate`.
- [x] Dependency policy and path validation passed.
- [x] Typecheck passed: `pnpm typecheck`.
- [x] Build passed: `pnpm build`.
- [x] Diff hygiene passed; only `pnpm-lock.yaml` changed.
- [ ] Full suite is not green on the unchanged base: 172 tests pass and one deterministic-clock test fails. The base-only failure is tracked by #84 and its fix is in #85; this PR does not modify that test or claim all tests pass.

## Checklist

- [x] I used a Conventional Commit title (e.g. `fix: ...`, `feat: ...`, `docs: ...`)
- [x] I linked related issue(s), or explained why none are needed
- [x] I did not include secrets, credentials, or private data
- [x] I called out any security-sensitive behavior changes
- [x] I updated docs when behavior or usage changed
