### PR TITLE
chore(ci): unblock maintenance validation

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2156,8 +2156,8 @@ packages:
     peerDependencies:
       seroval: ^1.0
 
-  seroval@1.5.2:
-    resolution: {integrity: sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==}
+  seroval@1.5.3:
+    resolution: {integrity: sha512-BXe0x4buEeYiIKaRUnth1WqCILQ3k4O67KP/B4pC3pVz0Mv2c96ngA9QDREUYxWY1sb2RZVRqwI9RcpVMyHCVw==}
     engines: {node: '>=10'}
 
   shebang-command@2.0.0:
@@ -4535,11 +4535,11 @@ snapshots:
 
   semver@7.7.4: {}
 
-  seroval-plugins@1.5.2(seroval@1.5.2):
+  seroval-plugins@1.5.2(seroval@1.5.3):
     dependencies:
-      seroval: 1.5.2
+      seroval: 1.5.3
 
-  seroval@1.5.2: {}
+  seroval@1.5.3: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -4564,8 +4564,8 @@ snapshots:
   solid-js@1.9.12:
     dependencies:
       csstype: 3.2.3
-      seroval: 1.5.2
-      seroval-plugins: 1.5.2(seroval@1.5.2)
+      seroval: 1.5.3
+      seroval-plugins: 1.5.2(seroval@1.5.3)
 
   source-map-js@1.2.1: {}
 

--- a/src/tui-maintenance.test.ts
+++ b/src/tui-maintenance.test.ts
@@ -134,6 +134,8 @@ describe("TUI maintenance timers", () => {
 
 describe("TUI state maintenance", () => {
   it("performs zero history reads for terminal children with complete tokens", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-17T09:02:00.000Z"));
     const { api, status, messages, part } = apiWithReadSpies();
     const current = state([child({ tokens: { total: 42 } })]);
 


### PR DESCRIPTION
## Summary

- Freeze the maintenance test clock within the terminal TTL so CI assertions remain deterministic.
- Update the locked transitive `seroval` resolution to remove the reported production vulnerability.

Closes #84
Closes #86

## Validation

- `./node_modules/.bin/tsc --noEmit -p tsconfig.json`
- `./node_modules/.bin/vitest run` (10 files, 173 tests passed)
- `./node_modules/.bin/tsup`
- `pnpm audit --prod --audit-level moderate` (no known vulnerabilities)
- `git diff --check origin/main...HEAD`

## Checklist

- [x] I used a Conventional Commit title (e.g. `fix: ...`, `feat: ...`, `docs: ...`)
- [x] I linked related issue(s), or explained why none are needed
- [x] I did not include secrets, credentials, or private data
- [x] I called out any security-sensitive behavior changes
- [x] I updated docs when behavior or usage changed
