### PR TITLE
fix(deps): support OpenTUI 0.5 peers

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
   "license": "MIT",
   "peerDependencies": {
     "@opencode-ai/plugin": ">=1.14.50 <2",
-    "@opentui/core": ">=0.4.0 <0.5",
-    "@opentui/solid": ">=0.4.0 <0.5",
+    "@opentui/core": ">=0.4.0 <0.6",
+    "@opentui/solid": ">=0.4.0 <0.6",
     "solid-js": ">=1.9.12 <2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- widen the `@opentui/core` peer range to include 0.5.x
- widen the `@opentui/solid` peer range to include 0.5.x
- restore npm installation compatibility with OpenCode 1.18.x

Closes #89

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts`
- manifest peer-range assertion
- `pnpm run pack:dry-run`
- clean packed-tarball consumer install with OpenCode 1.18.12 and OpenTUI 0.5.1
- `git diff --check`

Receipt-driven development is disabled for this clone; delivery is governed by ordinary repository policy (`disabled/unmanaged`).

## Checklist

- [x] I used a Conventional Commit title (e.g. `fix: ...`, `feat: ...`, `docs: ...`)
- [x] I linked related issue(s), or explained why none are needed
- [x] I did not include secrets, credentials, or private data
- [x] I called out any security-sensitive behavior changes
- [x] I updated docs when behavior or usage changed