### PR TITLE
feat(tui): show model and variant for child sessions

### DIFF
--- a/src/events.test.ts
+++ b/src/events.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   applySubagentEvent,
+  extractLatestAssistantModel,
   extractChildDetails,
   extractSessionID,
   extractTaskToolEvidence,
@@ -451,6 +452,157 @@ describe("events", () => {
       status: "error",
       endedAt: "2026-05-10T10:20:00.000Z",
     });
+  });
+});
+
+describe("assistant model metadata", () => {
+  it("normalizes direct messages and message envelopes", () => {
+    const direct = {
+      id: "msg_1",
+      sessionID: "ses_child",
+      role: "assistant",
+      providerID: "openai",
+      modelID: "gpt-5.6",
+      variant: "high",
+      time: { created: 10 },
+    };
+
+    expect(extractLatestAssistantModel(direct)?.model).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5.6",
+      variant: "high",
+    });
+    expect(extractLatestAssistantModel({ info: direct, parts: [] })?.model).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5.6",
+      variant: "high",
+    });
+  });
+
+  it("selects the latest assistant and applies message.updated to its child session", () => {
+    const latest = extractLatestAssistantModel([
+      {
+        info: {
+          sessionID: "ses_child",
+          role: "assistant",
+          providerID: "openai",
+          modelID: "old-model",
+          variant: "low",
+          time: { created: 10 },
+        },
+        parts: [],
+      },
+      {
+        sessionID: "ses_child",
+        role: "assistant",
+        providerID: "anthropic",
+        modelID: "new-model",
+        variant: "max",
+        time: { created: 20 },
+      },
+    ]);
+    expect(latest?.model).toEqual({
+      providerID: "anthropic",
+      modelID: "new-model",
+      variant: "max",
+    });
+
+    const state = createEmptyState();
+    applySubagentEvent(state, {
+      type: "session.created",
+      properties: { info: { id: "ses_child", parentID: "ses_parent", title: "Work" } },
+    });
+    applySubagentEvent(state, {
+      type: "message.updated",
+      properties: {
+        info: {
+          id: "msg_2",
+          sessionID: "ses_child",
+          role: "assistant",
+          providerID: "anthropic",
+          modelID: "new-model",
+          variant: "max",
+          time: { created: 20 },
+        },
+      },
+    });
+    expect(state.children.ses_child.model).toEqual(latest?.model);
+
+    applySubagentEvent(state, {
+      type: "message.updated",
+      properties: {
+        info: {
+          id: "msg_3",
+          sessionID: "ses_child",
+          role: "assistant",
+          providerID: "anthropic",
+          modelID: "new-model",
+          time: { created: 30 },
+        },
+      },
+    });
+    expect(state.children.ses_child.model).toEqual({
+      providerID: "anthropic",
+      modelID: "new-model",
+    });
+
+    applySubagentEvent(state, {
+      type: "message.updated",
+      properties: {
+        info: {
+          id: "msg_4",
+          sessionID: "ses_child",
+          role: "assistant",
+          providerID: "openai",
+          modelID: "next-model",
+          time: { created: 40 },
+        },
+      },
+    });
+    expect(state.children.ses_child.model).toEqual({
+      providerID: "openai",
+      modelID: "next-model",
+    });
+  });
+
+  it("associates child-session metadata with correlated wrappers", () => {
+    const state = createEmptyState();
+    applySubagentEvent(state, {
+      type: "message.part.updated",
+      properties: {
+        part: {
+          id: "part_1",
+          type: "tool",
+          tool: "task",
+          sessionID: "ses_parent",
+          messageID: "msg_parent",
+          state: {
+            status: "running",
+            metadata: { sessionId: "ses_child" },
+            input: { description: "Work" },
+          },
+        },
+      },
+    });
+    applySubagentEvent(state, {
+      type: "session.created",
+      properties: { info: { id: "ses_child", parentID: "ses_parent", title: "Work" } },
+    });
+    applySubagentEvent(state, {
+      type: "message.updated",
+      properties: {
+        info: {
+          sessionID: "ses_child",
+          role: "assistant",
+          providerID: "openai",
+          modelID: "gpt-5.6",
+          variant: "high",
+          time: { created: 20 },
+        },
+      },
+    });
+
+    expect(state.children.ses_child.model).toEqual(state.children["tool:part_1"].model);
   });
 });
 

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,10 +1,15 @@
-import type { ChildTokenState, StatuslineState } from "./state.js";
+import type {
+  ChildModelState,
+  ChildTokenState,
+  StatuslineState,
+} from "./state.js";
 import {
   deriveOpenCodeSessionStatus,
   hasStructuredErrorEvidence,
 } from "./reconcile.js";
 import {
   markChildStatus,
+  setChildModel,
   upsertChildDetails,
   upsertRunningChild,
 } from "./state.js";
@@ -80,6 +85,57 @@ type SyntheticTargetContext = {
 
 export function asString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function normalizeMessage(value: unknown): Record<string, unknown> | undefined {
+  const message = isRecord(value) ? value : undefined;
+  if (!message) return undefined;
+  return isRecord(message.info) ? message.info : message;
+}
+
+function messageActivityMs(message: Record<string, unknown>): number {
+  const time = isRecord(message.time) ? message.time : undefined;
+  const value = time?.completed ?? time?.updated ?? time?.created;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  }
+  return 0;
+}
+
+export function extractLatestAssistantModel(
+  input: unknown | readonly unknown[],
+): { sessionID: string; model?: ChildModelState; updatedAt?: string } | undefined {
+  const values = Array.isArray(input) ? input : [input];
+  const assistants = values
+    .map((value, index) => ({ message: normalizeMessage(value), index }))
+    .filter(
+      (entry): entry is { message: Record<string, unknown>; index: number } =>
+        entry.message?.role === "assistant",
+    )
+    .sort(
+      (left, right) =>
+        messageActivityMs(left.message) - messageActivityMs(right.message) ||
+        left.index - right.index,
+    );
+  const latest = assistants.at(-1)?.message;
+  if (!latest) return undefined;
+  const sessionID = asString(latest.sessionID);
+  if (!sessionID) return undefined;
+  const providerID = asString(latest.providerID)?.trim();
+  const modelID = asString(latest.modelID)?.trim();
+  const variant = asString(latest.variant)?.trim();
+  const model =
+    providerID && modelID
+      ? { providerID, modelID, ...(variant ? { variant } : {}) }
+      : undefined;
+  const activity = messageActivityMs(latest);
+  return {
+    sessionID,
+    model,
+    updatedAt: activity > 0 ? new Date(activity).toISOString() : undefined,
+  };
 }
 
 function conciseText(value: unknown): string | undefined {
@@ -983,6 +1039,16 @@ export function applySubagentEvent(
   }
 
   if (type === "message.updated") {
+    const assistantModel = extractLatestAssistantModel(e.properties?.info ?? e);
+    if (assistantModel) {
+      changed =
+        setChildModel(
+          state,
+          assistantModel.sessionID,
+          assistantModel.model,
+          assistantModel.updatedAt,
+        ) || changed;
+    }
     const completed = extractCompletedAssistantMessage(e);
     if (completed) {
       for (const child of Object.values(state.children)) {

--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -605,4 +605,21 @@ describe("state", () => {
     expect(loaded.countedChildIDs.ses_child).toBeUndefined();
     expect(loaded.countedChildIDs["subtask:old"]).toBeUndefined();
   });
+
+  it("sanitizes and retains model metadata through persistence", async () => {
+    const harness = await createRuntimeHarness();
+    const state = createEmptyState();
+    state.children.ses_child = child({
+      model: { providerID: " openai ", modelID: " gpt-5.6 ", variant: " high " },
+    });
+
+    await saveState(harness.statePath, state);
+    const loaded = await loadState(harness.statePath);
+
+    expect(loaded.children.ses_child.model).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5.6",
+      variant: "high",
+    });
+  });
 });

--- a/src/state.ts
+++ b/src/state.ts
@@ -16,6 +16,12 @@ export interface ChildTokenState {
   contextPercent?: number;
 }
 
+export interface ChildModelState {
+  providerID: string;
+  modelID: string;
+  variant?: string;
+}
+
 export interface ChildSessionState {
   id: string;
   title: string;
@@ -33,6 +39,7 @@ export interface ChildSessionState {
   endedAt?: string;
   elapsedMs?: number;
   tokens?: ChildTokenState;
+  model?: ChildModelState;
 }
 
 export interface StatuslineState {
@@ -223,6 +230,17 @@ function sanitizeTokens(input: unknown): ChildTokenState | undefined {
   return tokens;
 }
 
+function sanitizeModel(input: unknown): ChildModelState | undefined {
+  if (!input || typeof input !== "object") return undefined;
+  const raw = input as Record<string, unknown>;
+  const providerID =
+    typeof raw.providerID === "string" ? raw.providerID.trim() : "";
+  const modelID = typeof raw.modelID === "string" ? raw.modelID.trim() : "";
+  const variant = typeof raw.variant === "string" ? raw.variant.trim() : "";
+  if (!providerID || !modelID) return undefined;
+  return { providerID, modelID, ...(variant ? { variant } : {}) };
+}
+
 function sanitizeTargetSessionID(
   value: unknown,
   fallback?: string,
@@ -368,6 +386,7 @@ export function refreshDerivedFields(
       targetSessionID,
       color: statusColor(status),
       tokens: sanitizeTokens(child.tokens),
+      model: sanitizeModel(child.model),
       elapsedMs: resolveElapsedMs(
         {
           ...child,
@@ -595,6 +614,7 @@ export function upsertRunningChild(
     endedAt: shouldKeepCompletedTiming ? existing.endedAt : undefined,
     elapsedMs: existing?.elapsedMs,
     tokens: existing?.tokens,
+    model: existing?.model,
   };
 
   if (
@@ -611,7 +631,8 @@ export function upsertRunningChild(
     next.color === existing.color &&
     next.startedAt === existing.startedAt &&
     next.endedAt === existing.endedAt &&
-    sameTokens(next.tokens, existing.tokens)
+    sameTokens(next.tokens, existing.tokens) &&
+    JSON.stringify(next.model) === JSON.stringify(existing.model)
   ) {
     return counted;
   }
@@ -721,6 +742,29 @@ export function upsertChildDetails(
   state.children[childID] = next;
   state.updatedAt = observedUpdatedAt;
   return true;
+}
+
+export function setChildModel(
+  state: StatuslineState,
+  sessionID: string,
+  model: ChildModelState | undefined,
+  updatedAt?: string,
+): boolean {
+  const matches = Object.values(state.children).filter(
+    (child) => child.id === sessionID || child.targetSessionID === sessionID,
+  );
+  if (matches.length === 0) return false;
+
+  let changed = false;
+  const observedUpdatedAt = safeTimestamp(updatedAt, new Date().toISOString());
+  for (const child of matches) {
+    const sanitized = sanitizeModel(model);
+    if (JSON.stringify(child.model) === JSON.stringify(sanitized)) continue;
+    state.children[child.id] = { ...child, model: sanitized };
+    changed = true;
+  }
+  if (changed) state.updatedAt = observedUpdatedAt;
+  return changed;
 }
 
 export function getCounts(state: StatuslineState): StatusCounts {

--- a/src/subagent-classification.ts
+++ b/src/subagent-classification.ts
@@ -191,5 +191,6 @@ export function mergeProxyMetadataWithRealExecution(
     endedAt: real.endedAt,
     elapsedMs: real.elapsedMs,
     tokens: real.tokens,
+    model: real.model,
   };
 }

--- a/src/tui.test.ts
+++ b/src/tui.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 import { readOpenCodeLogFileIfSmall } from "./logs.js";
 import {
   backfillHydratedTargetSessionIDs,
+  formatChildModelLine,
   hydratePreviousSubagents,
   preservedSidebarAnchorScrollTop,
   preservedSidebarScrollTop,
@@ -126,6 +127,45 @@ describe("TUI subagent snapshots", () => {
         nowMs,
       }),
     ).toBe(2);
+  });
+
+  it("shows model metadata only with a variant and accounts for layout height", () => {
+    const nowMs = Date.parse("2026-04-30T10:20:00.000Z");
+    const plain = child({ title: "Short task" });
+    const modeled = child({
+      title: "Short task",
+      model: { providerID: "openai", modelID: "gpt-5.6", variant: "high" },
+    });
+    const providers = [{
+      id: "openai",
+      models: { "gpt-5.6": { name: "GPT 5.6" } },
+    }] as unknown as TuiPluginApi["state"]["provider"];
+
+    expect(formatChildModelLine(plain, providers, 20)).toBeUndefined();
+    expect(
+      formatChildModelLine(
+        child({ model: { providerID: "openai", modelID: "gpt-5.6" } }),
+        providers,
+        20,
+      ),
+    ).toBeUndefined();
+    expect(subagentRowHeight({ child: plain, nowMs })).toBe(2);
+    expect(formatChildModelLine(modeled, providers, 20)).toBe("GPT 5.6 · high");
+    expect(subagentRowHeight({ child: modeled, nowMs })).toBe(3);
+    expect(
+      formatChildModelLine(
+        child({ model: { providerID: "missing", modelID: "長いモデル識別子", variant: "最大" } }),
+        providers,
+        12,
+      ),
+    ).toSatisfy((line: string | undefined) => !!line && textColumns(line) <= 12);
+    expect(
+      formatChildModelLine(
+        child({ model: { providerID: "missing", modelID: "fallback-model", variant: "fast" } }),
+        providers,
+        40,
+      ),
+    ).toBe("fallback-model · fast");
   });
 
   it("preserves sidebar scroll with the visible row anchor first", () => {
@@ -858,6 +898,51 @@ describe("hydratePreviousSubagents", () => {
       resolveTuiSubagentSnapshot({ state, sessionID: "ses_parent" })
         .visibleCounts,
     ).toEqual({ running: 1, done: 0, error: 0 });
+  });
+
+  it("hydrates model metadata from direct and enveloped child messages", async () => {
+    const state = await hydrateState({
+      children: [
+        hydratedChild,
+        { ...hydratedChild, id: "ses_envelope" },
+      ],
+      childMessages: {
+        ses_child: [{
+          sessionID: "ses_child",
+          role: "assistant",
+          providerID: "openai",
+          modelID: "gpt-5.6",
+          variant: "high",
+          time: { created: 10 },
+        }],
+        ses_envelope: [{
+          info: {
+            sessionID: "ses_envelope",
+            role: "assistant",
+            providerID: "anthropic",
+            modelID: "claude-sonnet",
+            variant: "max",
+            time: { created: 20 },
+          },
+          parts: [],
+        }],
+      },
+      statuses: {
+        ses_child: { status: "running" },
+        ses_envelope: { status: "running" },
+      },
+    });
+
+    expect(state.children.ses_child.model).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5.6",
+      variant: "high",
+    });
+    expect(state.children.ses_envelope.model).toEqual({
+      providerID: "anthropic",
+      modelID: "claude-sonnet",
+      variant: "max",
+    });
   });
 
   it("hydrates terminal done and error evidence", async () => {

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -31,6 +31,7 @@ import type { Accessor } from "solid-js";
 import {
   applySubagentEvent,
   extractChildDetails,
+  extractLatestAssistantModel,
   extractTaskToolEvidence,
 } from "./events.js";
 import { readOpenCodeLogFileIfSmall } from "./logs.js";
@@ -74,6 +75,7 @@ import {
   resolveTextPath,
   saveState,
   saveStatusText,
+  setChildModel,
   upsertChildDetails,
   type ChildTokenState,
   type ChildSessionState,
@@ -110,10 +112,12 @@ const SUBAGENTS_SECTION_ENABLED_KV_KEY = "subagents.sidebar.enabled";
 const SUBAGENTS_MAX_VISIBLE_ROWS = 5;
 const SUBAGENTS_RUNNING_ROW_HEIGHT = 3;
 const SUBAGENTS_TERMINAL_ROW_HEIGHT = 2;
+const SUBAGENTS_MODEL_ROW_HEIGHT = 1;
 const SUBAGENTS_ROW_GAP = 0;
 const SUBAGENTS_ROW_MARKER_WIDTH = 4;
 const SUBAGENTS_MAX_LIST_HEIGHT =
-  SUBAGENTS_MAX_VISIBLE_ROWS * SUBAGENTS_RUNNING_ROW_HEIGHT +
+  SUBAGENTS_MAX_VISIBLE_ROWS *
+    (SUBAGENTS_RUNNING_ROW_HEIGHT + SUBAGENTS_MODEL_ROW_HEIGHT) +
   (SUBAGENTS_MAX_VISIBLE_ROWS - 1) * SUBAGENTS_ROW_GAP;
 const INACTIVE_SUBAGENT_OPACITY = 0.65;
 const SIDEBAR_VERSION_OPACITY = 0.7;
@@ -390,6 +394,7 @@ function cloneState(state: StatuslineState): StatuslineState {
         {
           ...child,
           tokens: child.tokens ? { ...child.tokens } : undefined,
+          model: child.model ? { ...child.model } : undefined,
         },
       ]),
     ),
@@ -1098,12 +1103,32 @@ export function subagentRowHeight(input: {
   sidebarWidth?: number;
   reservedWidth?: number;
 }): number {
-  if (input.child.status !== "running") return SUBAGENTS_TERMINAL_ROW_HEIGHT;
+  const modelHeight = input.child.model?.variant
+    ? SUBAGENTS_MODEL_ROW_HEIGHT
+    : 0;
+  if (input.child.status !== "running") {
+    return SUBAGENTS_TERMINAL_ROW_HEIGHT + modelHeight;
+  }
 
   const line = formatChildRowLine(input);
-  return line.secondaryLine
-    ? SUBAGENTS_RUNNING_ROW_HEIGHT
-    : SUBAGENTS_RUNNING_ROW_HEIGHT - 1;
+  return (
+    (line.secondaryLine
+      ? SUBAGENTS_RUNNING_ROW_HEIGHT
+      : SUBAGENTS_RUNNING_ROW_HEIGHT - 1) + modelHeight
+  );
+}
+
+export function formatChildModelLine(
+  child: ChildSessionState,
+  providers: TuiPluginApi["state"]["provider"],
+  width: number,
+): string | undefined {
+  if (!child.model?.variant) return undefined;
+  const provider = providers.find(
+    (candidate) => candidate.id === child.model?.providerID,
+  );
+  const name = provider?.models[child.model.modelID]?.name || child.model.modelID;
+  return ellipsize(`${name} · ${child.model.variant}`, Math.max(1, width));
 }
 
 export interface TuiSubagentSnapshot {
@@ -1225,6 +1250,9 @@ function SidebarSubagents(props: {
           child.tokens?.output ?? "",
           child.tokens?.total ?? "",
           child.tokens?.contextPercent ?? "",
+          child.model?.providerID ?? "",
+          child.model?.modelID ?? "",
+          child.model?.variant ?? "",
         ]),
       )
       .join("|"),
@@ -1596,6 +1624,15 @@ function SidebarSubagents(props: {
         reservedWidth: SUBAGENTS_ROW_MARKER_WIDTH,
       });
     });
+    const modelLine = createMemo(() => {
+      const currentChild = child();
+      if (!currentChild) return undefined;
+      return formatChildModelLine(
+        currentChild,
+        props.api.state.provider,
+        rowWidthBudget(props.sidebarWidth?.()) - SUBAGENTS_ROW_MARKER_WIDTH,
+      );
+    });
     const activate = () => {
       const target = targetSessionID();
       if (target) {
@@ -1689,6 +1726,11 @@ function SidebarSubagents(props: {
               <text
                 fg={emphasized() ? props.theme.text : props.theme.textMuted}
               >{`    ↳ ${CLOCK_ICON} ${terminalLine().meta}`}</text>
+              <Show when={modelLine()}>
+                {(metadata: Accessor<string>) => (
+                  <text fg={props.theme.textMuted}>{`    ${metadata()}`}</text>
+                )}
+              </Show>
             </box>
           }
         >
@@ -1729,6 +1771,11 @@ function SidebarSubagents(props: {
                 >{` ${TOKEN_ICON} ${line().meta}`}</text>
               </Show>
             </box>
+            <Show when={modelLine()}>
+              {(metadata: Accessor<string>) => (
+                <text fg={props.theme.textMuted}>{`    ${metadata()}`}</text>
+              )}
+            </Show>
           </box>
         </Show>
       </box>
@@ -1909,7 +1956,11 @@ export async function hydratePreviousSubagents(
       collectParentTaskEvidenceByChildSessionID(messages, currentSessionID);
     let childHydrationFailed = false;
     const childMessageResults: Array<
-      SessionMessageSummary & { childID?: string; fetchFailed: boolean }
+      SessionMessageSummary & {
+        childID?: string;
+        fetchFailed: boolean;
+        model?: ReturnType<typeof extractLatestAssistantModel>;
+      }
     > = await Promise.all(
       children.map(async (child) => {
         const session = asRecord(child);
@@ -1940,6 +1991,7 @@ export async function hydratePreviousSubagents(
         return {
           childID,
           ...summarizeSessionMessages(childMessages),
+          model: extractLatestAssistantModel(childMessages),
           fetchFailed,
         };
       }),
@@ -2006,6 +2058,15 @@ export async function hydratePreviousSubagents(
           },
         };
         if (applySubagentEvent(next, fakeEvent)) changed = true;
+        if (childSummary?.model) {
+          changed =
+            setChildModel(
+              next,
+              session.id,
+              childSummary.model.model,
+              childSummary.model.updatedAt,
+            ) || changed;
+        }
 
         const resolvedStatus = resolveSessionStatusWithMessageSummary({
           status: sessionStatus ?? parentTaskEvidence?.status,


### PR DESCRIPTION
Closes #82

## Summary

- Show a compact model and variant line for resolved child executions.
- Prefer the provider model name and fall back to `modelID`.
- Hide metadata when the latest assistant message has no variant, while preserving wrapper task rows.

## Validation

- `git diff --check`
- `./node_modules/.bin/tsc --noEmit -p tsconfig.json`
- `./node_modules/.bin/vitest run src/events.test.ts src/state.test.ts src/tui.test.ts` — 98 tests passed
- Shellcheck: N/A; no shell scripts changed.

## Security

No security-sensitive behavior changes. Model metadata remains in the existing local status state and TUI surface.

## Checklist

- [x] I used a Conventional Commit title (e.g. `fix: ...`, `feat: ...`, `docs: ...`)
- [x] I linked related issue(s), or explained why none are needed
- [x] I did not include secrets, credentials, or private data
- [x] I called out any security-sensitive behavior changes
- [x] I updated docs when behavior or usage changed, or confirmed no documentation change is required for this focused sidebar enhancement