### PR TITLE
docs(readme): improve project presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,17 @@
-# opencode-subagent-statusline
+# Subagent Monitor
 
 ![Subagents Monitor banner](https://raw.githubusercontent.com/Joaquinvesapa/sub-agent-statusline/main/assets/subagents_monitor_banner.webp)
 
-**Subagent Monitor for OpenCode.**
+See delegated work without leaving OpenCode. **Subagent Monitor** is an MIT-licensed OpenCode TUI sidebar plugin that keeps running, completed, and failed subagents visible, with elapsed time and token/context usage when OpenCode provides it.
 
-See what your subagents are doing without losing track of them: running, done, failed, elapsed time, and token/context usage when OpenCode exposes it.
-
-This package works as a **TUI sidebar plugin** for OpenCode.
-
----
-
-## Why?
-
-When you delegate work to subagents, they can disappear into the background. That is powerful, but it also makes it easy to lose visibility:
-
-- Is the review agent still running?
-- Did the test agent finish?
-- Which child session failed?
-- How much context did a subagent use?
-
-`opencode-subagent-statusline` adds a compact **Subagent Monitor** inside OpenCode so you can keep that information visible while you work.
-
----
-
-## Screenshot
-
-![Subagent Monitor inside OpenCode](https://raw.githubusercontent.com/Joaquinvesapa/sub-agent-statusline/main/assets/opencode_full.webp)
-
-Focused sidebar view:
-
-![Subagent Monitor sidebar](https://raw.githubusercontent.com/Joaquinvesapa/sub-agent-statusline/main/assets/opencode_sidebar.webp)
-
----
+[![npm version](https://img.shields.io/npm/v/opencode-subagent-statusline?style=flat-square)](https://www.npmjs.com/package/opencode-subagent-statusline)
+[![monthly npm downloads](https://img.shields.io/npm/dm/opencode-subagent-statusline?style=flat-square)](https://www.npmjs.com/package/opencode-subagent-statusline)
+[![GitHub stars](https://img.shields.io/github/stars/Joaquinvesapa/sub-agent-statusline?style=flat-square)](https://github.com/Joaquinvesapa/sub-agent-statusline)
+[![license](https://img.shields.io/github/license/Joaquinvesapa/sub-agent-statusline?style=flat-square)](LICENSE)
 
 ## Install
 
-Add the plugin to your OpenCode TUI config:
+Add the package to your OpenCode TUI configuration:
 
 ```json
 {
@@ -44,29 +20,76 @@ Add the plugin to your OpenCode TUI config:
 }
 ```
 
-Your TUI config usually lives at:
+The configuration usually lives at:
 
 ```txt
 ~/.config/opencode/tui.json
 ```
 
-Restart OpenCode after editing the file.
+Restart OpenCode after saving the file. The package is published as `opencode-subagent-statusline` and requires Node `>=22.13`.
 
----
+## Why Subagent Monitor?
+
+Delegating work is powerful, but child sessions can disappear into the background. Without a visible status surface, you have to guess:
+
+- Is the review agent still running?
+- Did the test agent finish?
+- Which child session failed?
+- How much context did a subagent use?
+
+Subagent Monitor restores that visibility inside OpenCode, so you can keep working while still knowing what your delegated agents are doing.
 
 ## What you get
 
-The TUI plugin adds a sidebar section that shows:
+The sidebar shows:
 
-- running subagents
-- recent completed subagents, with a manual completed history toggle for retained older completions
-- failed subagents
-- elapsed time
-- token/context usage when available
+- running subagents;
+- recent completed subagents;
+- failed subagents;
+- elapsed time;
+- token/context usage when available.
 
-It also adds a small home/footer summary when there is active subagent activity.
+When subagent activity is active, the plugin also adds a compact summary to the home/footer area.
 
-## 1.0 public contract
+## Gentle AI integration
+
+[Gentle AI](https://github.com/Gentleman-Programming/gentle-ai) offers Subagent Monitor as an optional OpenCode community plugin. Select and install it through Gentle AI to add the selected plugin to OpenCode's `tui.json`, or install this package directly using the configuration above.
+
+This integration is optional. Subagent Monitor remains an independently installable OpenCode plugin.
+
+## Screenshots
+
+Full OpenCode context with demo content in Spanish:
+
+![Subagent Monitor in the full OpenCode view](https://raw.githubusercontent.com/Joaquinvesapa/sub-agent-statusline/main/assets/opencode_full.webp)
+
+Focused sidebar view:
+
+![Subagent Monitor focused sidebar](https://raw.githubusercontent.com/Joaquinvesapa/sub-agent-statusline/main/assets/opencode_sidebar.webp)
+
+## Keyboard navigation
+
+Run `Subagents: Focus sidebar list` from the OpenCode command palette, or press `Alt+B`, to focus the subagent sidebar list without using the mouse. List navigation shortcuts are handled only while the sidebar list is focused.
+
+| Shortcut | Action |
+| --- | --- |
+| `Alt+B` | Toggle focus between the subagent sidebar list and the prompt. |
+| `j` / `ArrowDown` | Move selection to the next visible subagent. |
+| `k` / `ArrowUp` | Move selection to the previous visible subagent. |
+| `Enter` | Open the selected subagent session. |
+| `c` | Toggle retained completed history in the sidebar. |
+| `h` / `ArrowLeft` | Collapse the subagent section. |
+| `l` / `ArrowRight` | Expand the subagent section. |
+| `Esc` | Leave list focus mode and return to the prompt. |
+
+Opening a selected session is a no-op when there is no visible or navigable subagent.
+
+Click `Σ` in the sidebar aggregate row to toggle completed history with the mouse. The toggle is not persisted; it resets when OpenCode or the plugin is reloaded. Completed history is bounded retained history, not a full database: terminal rows are kept for up to 3 days with a 1,500-row cap, and rows already pruned from state are not restored.
+
+When a child session is opened from the sidebar, returning with OpenCode `Up` (`session_parent`) moves keyboard focus to the parent prompt so you can type immediately.
+
+<details>
+<summary>Stable 1.x public contract</summary>
 
 For 1.x releases, the stable user-facing contract is:
 
@@ -87,127 +110,15 @@ Experimental or internal surfaces may change in 1.x without a SemVer-major bump:
 
 Use the TUI plugin entrypoints for normal OpenCode usage.
 
-## Keyboard navigation
-
-Run `Subagents: Focus sidebar list` from the OpenCode command palette, or press
-`Alt+B`, to focus the subagent sidebar list without using the mouse. List
-navigation shortcuts are handled only while the sidebar list is focused.
-
-| Shortcut           | Action                                                         |
-| ------------------ | -------------------------------------------------------------- |
-| `Alt+B`            | Toggle focus between the subagent sidebar list and the prompt. |
-| `j` / `ArrowDown`  | Move selection to the next visible subagent.                   |
-| `k` / `ArrowUp`    | Move selection to the previous visible subagent.               |
-| `Enter`            | Open the selected subagent session.                            |
-| `c`                | Toggle retained completed history in the sidebar.              |
-| `h` / `ArrowLeft`  | Collapse the subagent section.                                 |
-| `l` / `ArrowRight` | Expand the subagent section.                                   |
-| `Esc`              | Leave list focus mode and return to the prompt.                |
-
-Opening a selected session is a no-op when there is no visible or navigable
-subagent.
-
-Click `Σ` in the sidebar aggregate row to toggle completed history with the
-mouse. The toggle is not persisted; it resets when OpenCode or the plugin is
-reloaded. Completed history is bounded retained history, not a full database:
-terminal rows are kept for up to 3 days with a 1,500-row cap, and rows already
-pruned from state are not restored.
-
-When a child session is opened from the sidebar, returning with OpenCode `Up`
-(`session_parent`) moves keyboard focus to the parent prompt so you can type
-immediately.
-
----
+</details>
 
 ## Documentation
 
-For a deeper explanation of how the plugin works, see the structured docs:
+For deeper installation, architecture, event-flow, state, rendering, TUI, configuration, testing, and troubleshooting details:
 
 - [English documentation](docs/en/00-index.md)
 - [Documentación en español](docs/es/00-indice.md)
-
-They cover installation, architecture, event flow, state/counters, rendering,
-TUI behavior, advanced configuration, development/testing, and troubleshooting.
-
----
-
-## Local development
-
-Install dependencies with lifecycle scripts disabled by default:
-
-```sh
-pnpm install --ignore-scripts
-```
-
-Build the plugin:
-
-```sh
-pnpm build
-```
-
-Test the local TUI build by pointing OpenCode directly at `dist/tui.js`:
-
-```json
-{
-  "$schema": "https://opencode.ai/tui.json",
-  "plugin": ["/absolute/path/to/sub-agent-statusline/dist/tui.js"]
-}
-```
-
-## Development notes
-
-This project ships the OpenCode TUI sidebar plugin from `src/tui.tsx`.
-
-The TUI bundle is built with `tsup` and `esbuild-plugin-solid` in Solid `universal` mode for OpenTUI compatibility.
-
-Package entrypoints:
-
-```txt
-opencode-subagent-statusline          -> TUI plugin
-opencode-subagent-statusline/tui      -> TUI plugin
-opencode-subagent-statusline/runtime  -> experimental/diagnostic runtime mode
-```
-
-Useful commands:
-
-```sh
-pnpm build
-pnpm typecheck
-pnpm test
-pnpm test:watch
-pnpm test:coverage
-pnpm pack --dry-run
-```
-
-## Security hardening for maintainers
-
-Recommended local npm/pnpm hygiene, following guidance from Gentle AI and Liran Tal:
-
-- install project dependencies with lifecycle scripts disabled when possible, for example `pnpm install --ignore-scripts`;
-- consider setting user-level `ignore-scripts=true` for npm/pnpm and temporarily opt in only when a trusted package needs scripts;
-- enable dependency age/cooldown policies where supported, for example `npm config set min-release-age 3` or equivalent Renovate/Dependabot cooldowns;
-- block or review git, tarball, URL, and other exotic dependency specs, for example `npm config set allow-git none` where supported;
-- optionally screen new packages with tools such as `npq` or Socket Firewall before adding them.
-
-These are maintainer/developer controls, not runtime enforcement by this plugin.
-
-Release maintainers should also keep npm trusted publishing/OIDC enabled for this package, require npm 2FA on maintainer accounts, restrict and revoke legacy npm tokens once OIDC publishing is active, and protect the release branch in GitHub.
-
-## Testing
-
-Automated tests use Vitest with `@vitest/coverage-v8`:
-
-```sh
-pnpm test
-pnpm test:watch
-pnpm test:coverage
-pnpm typecheck
-```
-
-For the testing strategy, file map, examples, and current TUI/e2e boundaries, see
-[`docs/testing.md`](docs/testing.md).
-
----
+- [Testing strategy](docs/testing.md)
 
 ## Troubleshooting
 
@@ -243,8 +154,82 @@ The plugin persists a local JSON state file and `status.txt` snapshot under `XDG
 
 For token/context backfill, the TUI reads recent local OpenCode SQLite/log data only from the user's OpenCode data directory. Very large log files are skipped to avoid blocking the TUI.
 
----
+<details>
+<summary>Development and testing</summary>
+
+Install dependencies with lifecycle scripts disabled by default:
+
+```sh
+pnpm install --ignore-scripts
+```
+
+Build the plugin:
+
+```sh
+pnpm build
+```
+
+Test a local TUI build by pointing OpenCode directly at `dist/tui.js`:
+
+```json
+{
+  "$schema": "https://opencode.ai/tui.json",
+  "plugin": ["/absolute/path/to/sub-agent-statusline/dist/tui.js"]
+}
+```
+
+This project ships the OpenCode TUI sidebar plugin from `src/tui.tsx`. The TUI bundle is built with `tsup` and `esbuild-plugin-solid` in Solid `universal` mode for OpenTUI compatibility.
+
+Package entrypoints:
+
+```txt
+opencode-subagent-statusline          -> TUI plugin
+opencode-subagent-statusline/tui      -> TUI plugin
+opencode-subagent-statusline/runtime  -> experimental/diagnostic runtime mode
+```
+
+Useful commands:
+
+```sh
+pnpm build
+pnpm typecheck
+pnpm test
+pnpm test:watch
+pnpm test:coverage
+pnpm pack --dry-run
+```
+
+Automated tests use Vitest with `@vitest/coverage-v8`. For the testing strategy, file map, examples, and current TUI/e2e boundaries, see [`docs/testing.md`](docs/testing.md).
+
+</details>
+
+<details>
+<summary>Security hardening for maintainers</summary>
+
+Recommended local npm/pnpm hygiene, following guidance from Gentle AI and Liran Tal:
+
+- install project dependencies with lifecycle scripts disabled when possible, for example `pnpm install --ignore-scripts`;
+- consider setting user-level `ignore-scripts=true` for npm/pnpm and temporarily opt in only when a trusted package needs scripts;
+- enable dependency age/cooldown policies where supported, for example `npm config set min-release-age 3` or equivalent Renovate/Dependabot cooldowns;
+- block or review git, tarball, URL, and other exotic dependency specs, for example `npm config set allow-git none` where supported;
+- optionally screen new packages with tools such as `npq` or Socket Firewall before adding them.
+
+These are maintainer/developer controls, not runtime enforcement by this plugin.
+
+Release maintainers should also keep npm trusted publishing/OIDC enabled for this package, require npm 2FA on maintainer accounts, restrict and revoke legacy npm tokens once OIDC publishing is active, and protect the release branch in GitHub.
+
+</details>
+
+## Community and releases
+
+- [npm package](https://www.npmjs.com/package/opencode-subagent-statusline)
+- [GitHub repository](https://github.com/Joaquinvesapa/sub-agent-statusline)
+- [Releases](https://github.com/Joaquinvesapa/sub-agent-statusline/releases)
+- [Issues](https://github.com/Joaquinvesapa/sub-agent-statusline/issues)
+- [Contributing](CONTRIBUTING.md)
+- [Code of Conduct](CODE_OF_CONDUCT.md)
+- [Security policy](SECURITY.md)
 
 ## License
 
-MIT
+[MIT](LICENSE)


### PR DESCRIPTION
Closes #92

## Summary

- Reframe the README as a clearer product landing page for Subagent Monitor.
- Add dynamic trust badges, a quick installation path, screenshots, and the verified optional Gentle AI integration.
- Preserve detailed usage, privacy, troubleshooting, development, testing, security, and license information through progressive disclosure.

## Validation

- `git diff --check origin/main...HEAD`
- Manually reviewed the rendered Markdown structure and links.
- Documentation-only change; runtime tests are not applicable.

## Checklist

- [x] I used a Conventional Commit title (e.g. `fix: ...`, `feat: ...`, `docs: ...`)
- [x] I linked related issue(s), or explained why none are needed
- [x] I did not include secrets, credentials, or private data
- [x] I called out any security-sensitive behavior changes (none)
- [x] I updated docs when behavior or usage changed